### PR TITLE
feat(home): Home Page — trending grid, PodcastCardComponent, skeleton loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,9 @@
 - The `nx-generate` skill handles generator discovery internally - don't call nx_docs just to look up generator syntax
 
 <!-- nx configuration end-->
+
+## Project Management
+
+- **Task tracker**: GitHub Issues on `bndF1/wavely` (NOT Linear)
+- GitHub MCP tools are read-only; issue creation requires `gh auth login` or a PAT passed via env
+- To authenticate: `gh auth login` or `export GITHUB_TOKEN=<pat>` then use `gh` CLI

--- a/src/app/core/services/podcast-api.service.ts
+++ b/src/app/core/services/podcast-api.service.ts
@@ -1,10 +1,9 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, map } from 'rxjs';
-import { Podcast, Episode } from '../models/podcast.model';
+import { Podcast } from '../models/podcast.model';
 
-// Uses iTunes Search API (no key required) as primary source,
-// with Podcast Index API as enhanced fallback once credentials are set.
+// Uses iTunes Search API (no key required) as primary data source.
 @Injectable({ providedIn: 'root' })
 export class PodcastApiService {
   private readonly http = inject(HttpClient);
@@ -28,6 +27,17 @@ export class PodcastApiService {
       .pipe(map((res) => this.mapItunesPodcast(res.results[0])));
   }
 
+  /**
+   * Fetch top podcasts chart via the iTunes RSS feed.
+   * Endpoint: https://itunes.apple.com/us/rss/toppodcasts/limit=N/json
+   */
+  getTrendingPodcasts(limit = 25): Observable<Podcast[]> {
+    const url = `${this.itunesBase}/us/rss/toppodcasts/limit=${limit}/json`;
+    return this.http
+      .get<ItunesRssFeed>(url)
+      .pipe(map((feed) => feed.feed.entry.map(this.mapRssEntry)));
+  }
+
   private mapItunesPodcast(raw: ItunesPodcast): Podcast {
     return {
       id: String(raw.collectionId),
@@ -39,6 +49,22 @@ export class PodcastApiService {
       genres: raw.genres ?? [],
       episodeCount: raw.trackCount,
       latestReleaseDate: raw.releaseDate,
+    };
+  }
+
+  private mapRssEntry(entry: ItunesRssEntry): Podcast {
+    // Artwork comes as 55x55 / 60x60 / 170x170 — take last (largest) and upscale URL
+    const artworkUrl = (entry['im:image']?.at(-1)?.label ?? '')
+      .replace(/\/\d+x\d+bb\./, '/600x600bb.');
+    const genreAttr = entry.category?.attributes;
+    return {
+      id: entry.id.attributes['im:id'],
+      title: entry['im:name'].label,
+      author: entry['im:artist']?.label ?? '',
+      description: entry.summary?.label ?? '',
+      artworkUrl,
+      feedUrl: '',
+      genres: genreAttr?.label ? [genreAttr.label] : [],
     };
   }
 }
@@ -53,4 +79,17 @@ interface ItunesPodcast {
   genres: string[];
   trackCount: number;
   releaseDate: string;
+}
+
+interface ItunesRssEntry {
+  'im:name': { label: string };
+  'im:artist'?: { label: string };
+  'im:image'?: Array<{ label: string; attributes: { height: string } }>;
+  id: { label: string; attributes: { 'im:id': string } };
+  summary?: { label: string };
+  category?: { attributes: { 'im:id': string; term: string; label: string } };
+}
+
+interface ItunesRssFeed {
+  feed: { entry: ItunesRssEntry[] };
 }

--- a/src/app/features/home/home.page.html
+++ b/src/app/features/home/home.page.html
@@ -1,8 +1,74 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>Home</ion-title>
+    <ion-title>
+      <span class="header-logo">Wavely</span>
+    </ion-title>
+    <ion-buttons slot="end">
+      <ion-button (click)="navigateToSearch()" aria-label="Search podcasts">
+        <ion-icon slot="icon-only" name="search-outline"></ion-icon>
+      </ion-button>
+    </ion-buttons>
   </ion-toolbar>
 </ion-header>
-<ion-content class="ion-padding">
-  <!-- Home content -->
+
+<ion-content>
+  <ion-refresher slot="fixed" (ionRefresh)="handleRefresh($event)">
+    <ion-refresher-content></ion-refresher-content>
+  </ion-refresher>
+
+  <!-- ── My Subscriptions ── -->
+  <ng-container *ngIf="store.subscriptions().length > 0">
+    <section class="home-section">
+      <h2 class="section-title">My Podcasts</h2>
+      <div class="subscriptions-scroll">
+        <div class="subscriptions-row">
+          <wavely-podcast-card
+            *ngFor="let podcast of store.subscriptions()"
+            class="subscription-card"
+            [podcast]="podcast"
+            (cardClick)="navigateToPodcast($event)">
+          </wavely-podcast-card>
+        </div>
+      </div>
+    </section>
+  </ng-container>
+
+  <!-- ── Trending ── -->
+  <section class="home-section">
+    <h2 class="section-title">Trending</h2>
+
+    <!-- Error state -->
+    <div *ngIf="store.error() && !store.isLoading()" class="error-state">
+      <ion-text color="medium">
+        <p>{{ store.error() }}</p>
+      </ion-text>
+    </div>
+
+    <!-- Loading skeletons -->
+    <div *ngIf="store.isLoading()" class="podcast-grid">
+      <wavely-podcast-card
+        *ngFor="let s of skeletons"
+        [podcast]="skeletonPodcast"
+        [loading]="true">
+      </wavely-podcast-card>
+    </div>
+
+    <!-- Trending grid -->
+    <div *ngIf="!store.isLoading() && store.trending().length > 0" class="podcast-grid">
+      <wavely-podcast-card
+        *ngFor="let podcast of store.trending()"
+        [podcast]="podcast"
+        (cardClick)="navigateToPodcast($event)">
+      </wavely-podcast-card>
+    </div>
+
+    <!-- Empty state (no error, no loading, no results) -->
+    <div
+      *ngIf="!store.isLoading() && !store.error() && store.trending().length === 0"
+      class="empty-state">
+      <ion-text color="medium">
+        <p>No trending podcasts found.</p>
+      </ion-text>
+    </div>
+  </section>
 </ion-content>

--- a/src/app/features/home/home.page.scss
+++ b/src/app/features/home/home.page.scss
@@ -1,0 +1,68 @@
+.home-page {
+  --padding-start: 16px;
+  --padding-end: 16px;
+}
+
+.home-section {
+  padding: 20px 16px 8px;
+}
+
+.section-title {
+  margin: 0 0 14px;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--wavely-on-surface);
+  letter-spacing: -0.2px;
+}
+
+.podcast-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+/* Horizontal subscription scroll */
+.subscriptions-scroll {
+  overflow-x: auto;
+  margin: 0 -16px;
+  padding: 0 16px;
+  scrollbar-width: none;
+  &::-webkit-scrollbar { display: none; }
+}
+
+.subscriptions-row {
+  display: flex;
+  gap: 12px;
+  padding-bottom: 8px;
+}
+
+.subscription-card {
+  flex: 0 0 120px;
+  width: 120px;
+}
+
+/* Header */
+.header-logo {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--wavely-primary);
+  letter-spacing: -0.5px;
+}
+
+.header-icon {
+  font-size: 22px;
+  padding: 0 16px;
+  cursor: pointer;
+  color: var(--wavely-on-surface);
+}
+
+/* Error / empty */
+.error-state,
+.empty-state {
+  padding: 32px 16px;
+  text-align: center;
+  ion-text p {
+    font-size: 14px;
+    line-height: 1.5;
+  }
+}

--- a/src/app/features/home/home.page.ts
+++ b/src/app/features/home/home.page.ts
@@ -1,15 +1,104 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, inject, signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { NgFor, NgIf } from '@angular/common';
 import {
   IonHeader,
   IonToolbar,
   IonTitle,
   IonContent,
+  IonRefresher,
+  IonRefresherContent,
+  IonText,
+  IonButtons,
+  IonButton,
+  IonIcon,
+  RefresherCustomEvent,
 } from '@ionic/angular/standalone';
+import { addIcons } from 'ionicons';
+import { searchOutline } from 'ionicons/icons';
+import { PodcastApiService } from '../../core/services/podcast-api.service';
+import { PodcastsStore } from '../../store/podcasts/podcasts.store';
+import { PodcastCardComponent } from '../../shared/components/podcast-card/podcast-card.component';
+import { Podcast } from '../../core/models/podcast.model';
+
+/** Dummy skeleton items used while data loads */
+const SKELETON_COUNT = 6;
 
 @Component({
   selector: 'wavely-home',
   templateUrl: './home.page.html',
   styleUrls: ['./home.page.scss'],
-  imports: [IonHeader, IonToolbar, IonTitle, IonContent],
+  imports: [
+    NgFor,
+    NgIf,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonRefresher,
+    IonRefresherContent,
+    IonText,
+    IonButtons,
+    IonButton,
+    IonIcon,
+    PodcastCardComponent,
+  ],
 })
-export class HomePage {}
+export class HomePage implements OnInit {
+  private readonly api = inject(PodcastApiService);
+  protected readonly store = inject(PodcastsStore);
+  private readonly router = inject(Router);
+
+  /** Skeleton placeholder array */
+  protected readonly skeletons = Array.from({ length: SKELETON_COUNT });
+  /** Dummy podcast used to satisfy required `podcast` input during skeleton render */
+  protected readonly skeletonPodcast: Podcast = {
+    id: '',
+    title: '',
+    author: '',
+    description: '',
+    artworkUrl: '',
+    feedUrl: '',
+    genres: [],
+  };
+
+  constructor() {
+    addIcons({ searchOutline });
+  }
+
+  ngOnInit(): void {
+    if (this.store.trending().length === 0) {
+      this.loadTrending();
+    }
+  }
+
+  protected async handleRefresh(event: RefresherCustomEvent): Promise<void> {
+    await this.loadTrending();
+    event.detail.complete();
+  }
+
+  protected navigateToPodcast(podcast: Podcast): void {
+    this.router.navigate(['/podcast', podcast.id]);
+  }
+
+  protected navigateToSearch(): void {
+    this.router.navigate(['/tabs/search']);
+  }
+
+  private loadTrending(): Promise<void> {
+    this.store.setLoading(true);
+    return new Promise((resolve) => {
+      this.api.getTrendingPodcasts(25).subscribe({
+        next: (podcasts) => {
+          this.store.setTrending(podcasts);
+          this.store.setLoading(false);
+          resolve();
+        },
+        error: () => {
+          this.store.setError('Could not load trending podcasts. Pull down to retry.');
+          resolve();
+        },
+      });
+    });
+  }
+}

--- a/src/app/shared/components/podcast-card/podcast-card.component.html
+++ b/src/app/shared/components/podcast-card/podcast-card.component.html
@@ -1,0 +1,33 @@
+<article
+  class="podcast-card"
+  [class.podcast-card--skeleton]="loading()"
+  (click)="!loading() && cardClick.emit(podcast())"
+  [attr.role]="loading() ? null : 'button'"
+  [attr.tabindex]="loading() ? null : 0"
+  (keydown.enter)="!loading() && cardClick.emit(podcast())"
+  (keydown.space)="onSpaceKey($event)">
+
+  <div class="podcast-card__artwork">
+    <ng-container *ngIf="!loading(); else skeletonArtwork">
+      <img
+        [src]="podcast().artworkUrl || '/default-artwork.svg'"
+        [alt]="podcast().title"
+        loading="lazy"
+        (error)="onImageError($event)" />
+    </ng-container>
+    <ng-template #skeletonArtwork>
+      <div class="skeleton-box podcast-card__skeleton-artwork"></div>
+    </ng-template>
+  </div>
+
+  <div class="podcast-card__meta">
+    <ng-container *ngIf="!loading(); else skeletonMeta">
+      <p class="podcast-card__title">{{ podcast().title }}</p>
+      <p class="podcast-card__author">{{ podcast().author }}</p>
+    </ng-container>
+    <ng-template #skeletonMeta>
+      <div class="skeleton-box podcast-card__skeleton-title"></div>
+      <div class="skeleton-box podcast-card__skeleton-author"></div>
+    </ng-template>
+  </div>
+</article>

--- a/src/app/shared/components/podcast-card/podcast-card.component.scss
+++ b/src/app/shared/components/podcast-card/podcast-card.component.scss
@@ -1,0 +1,98 @@
+:host {
+  display: block;
+}
+
+.podcast-card {
+  cursor: pointer;
+  outline: none;
+
+  &:focus-visible .podcast-card__artwork {
+    outline: 2px solid var(--wavely-primary);
+    outline-offset: 2px;
+  }
+
+  &--skeleton {
+    cursor: default;
+    pointer-events: none;
+  }
+
+  &__artwork {
+    border-radius: 12px;
+    overflow: hidden;
+    aspect-ratio: 1;
+    background: var(--wavely-surface-variant);
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+      transition: transform 0.2s ease;
+    }
+  }
+
+  &:active:not(&--skeleton) &__artwork img {
+    transform: scale(0.96);
+  }
+
+  &__meta {
+    padding: 6px 2px 0;
+  }
+
+  &__title {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--wavely-on-surface);
+    line-height: 1.3;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  &__author {
+    margin: 2px 0 0;
+    font-size: 11px;
+    color: var(--wavely-on-surface-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  // Skeleton styles
+  &__skeleton-artwork {
+    width: 100%;
+    height: 100%;
+  }
+
+  &__skeleton-title {
+    height: 12px;
+    width: 90%;
+    border-radius: 4px;
+  }
+
+  &__skeleton-author {
+    height: 10px;
+    width: 60%;
+    border-radius: 4px;
+    margin-top: 6px;
+  }
+}
+
+// Skeleton shimmer animation (global pattern)
+.skeleton-box {
+  background: linear-gradient(
+    90deg,
+    var(--wavely-surface-variant) 25%,
+    var(--wavely-divider) 50%,
+    var(--wavely-surface-variant) 75%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.5s infinite;
+}
+
+@keyframes skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/src/app/shared/components/podcast-card/podcast-card.component.ts
+++ b/src/app/shared/components/podcast-card/podcast-card.component.ts
@@ -1,0 +1,29 @@
+import { Component, input, output } from '@angular/core';
+import { NgIf } from '@angular/common';
+import { Podcast } from '../../../core/models/podcast.model';
+
+@Component({
+  selector: 'wavely-podcast-card',
+  templateUrl: './podcast-card.component.html',
+  styleUrls: ['./podcast-card.component.scss'],
+  imports: [NgIf],
+})
+export class PodcastCardComponent {
+  readonly podcast = input.required<Podcast>();
+  /** Emitted when the card is tapped */
+  readonly cardClick = output<Podcast>();
+
+  /** Show skeleton loading state instead of content */
+  readonly loading = input<boolean>(false);
+
+  onImageError(event: Event): void {
+    const img = event.target as HTMLImageElement;
+    img.src = '/default-artwork.svg';
+  }
+
+  onSpaceKey(event: Event): void {
+    if (this.loading()) return;
+    event.preventDefault();
+    this.cardClick.emit(this.podcast());
+  }
+}


### PR DESCRIPTION
## Summary
Implements the Home Page (closes #2) and introduces the shared `PodcastCardComponent`.

## Changes
- **`PodcastCardComponent`** (new, shared): artwork with fallback, title/author, skeleton shimmer, accessible keyboard nav (Enter + Space with scroll prevention)
- **`HomePage`**: trending grid (2-col), subscriptions horizontal scroll, pull-to-refresh, skeleton placeholders, error/empty states
- **`PodcastApiService`**: fixed `getTrendingPodcasts()` — switched to correct iTunes RSS endpoint (`itunes.apple.com/us/rss/toppodcasts`)
- **Search icon**: wrapped in `IonButton` for proper keyboard accessibility

## Reviewer findings fixed
- ❌ Invalid trending API URL → ✅ corrected to iTunes RSS feed
- ❌ Search icon not keyboard-accessible → ✅ wrapped in IonButton
- ❌ Space key caused scroll + navigation → ✅ `event.preventDefault()` added

## Verification
- `bun run build` ✅ — zero errors, pre-existing budget warnings unchanged