### PR TITLE
feat(browse): Browse page — category chips + top charts

### DIFF
--- a/src/app/core/services/podcast-api.service.ts
+++ b/src/app/core/services/podcast-api.service.ts
@@ -29,10 +29,13 @@ export class PodcastApiService {
 
   /**
    * Fetch top podcasts chart via the iTunes RSS feed.
-   * Endpoint: https://itunes.apple.com/us/rss/toppodcasts/limit=N/json
+   * @param limit Number of results (max 100). Default 25.
+   * @param genreId Optional iTunes genre ID. Omit for overall top chart.
+   * Endpoint: https://itunes.apple.com/us/rss/toppodcasts/limit=N/genre/ID/json
    */
-  getTrendingPodcasts(limit = 25): Observable<Podcast[]> {
-    const url = `${this.itunesBase}/us/rss/toppodcasts/limit=${limit}/json`;
+  getTrendingPodcasts(limit = 25, genreId?: number): Observable<Podcast[]> {
+    const genrePath = genreId ? `/genre/${genreId}` : '';
+    const url = `${this.itunesBase}/us/rss/toppodcasts/limit=${limit}${genrePath}/json`;
     return this.http
       .get<ItunesRssFeed>(url)
       .pipe(map((feed) => feed.feed.entry.map(this.mapRssEntry)));

--- a/src/app/features/browse/browse.page.html
+++ b/src/app/features/browse/browse.page.html
@@ -3,6 +3,46 @@
     <ion-title>Browse</ion-title>
   </ion-toolbar>
 </ion-header>
-<ion-content class="ion-padding">
-  <!-- Browse content -->
+
+<ion-content>
+  <!-- Category chips -->
+  <div class="category-scroll">
+    <div class="category-row">
+      <ion-chip
+        *ngFor="let cat of categories"
+        [class.selected]="selectedCategory.id === cat.id"
+        [style.--chip-color]="cat.color"
+        (click)="selectCategory(cat)">
+        <ion-label>{{ cat.name }}</ion-label>
+      </ion-chip>
+    </div>
+  </div>
+
+  <!-- Loading skeletons -->
+  <div *ngIf="isLoading" class="podcast-grid">
+    <wavely-podcast-card
+      *ngFor="let s of skeletons"
+      [podcast]="skeletonPodcast"
+      [loading]="true">
+    </wavely-podcast-card>
+  </div>
+
+  <!-- Results -->
+  <div *ngIf="!isLoading && topPodcasts.length > 0" class="podcast-grid">
+    <wavely-podcast-card
+      *ngFor="let podcast of topPodcasts"
+      [podcast]="podcast"
+      (cardClick)="navigateToPodcast($event)">
+    </wavely-podcast-card>
+  </div>
+
+  <!-- Error -->
+  <div *ngIf="error && !isLoading" class="state-message">
+    <ion-text color="medium"><p>{{ error }}</p></ion-text>
+  </div>
+
+  <!-- Empty -->
+  <div *ngIf="!isLoading && !error && topPodcasts.length === 0" class="state-message">
+    <ion-text color="medium"><p>No podcasts found in this category.</p></ion-text>
+  </div>
 </ion-content>

--- a/src/app/features/browse/browse.page.scss
+++ b/src/app/features/browse/browse.page.scss
@@ -1,0 +1,41 @@
+.category-scroll {
+  overflow-x: auto;
+  padding: 12px 16px 4px;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: var(--wavely-background);
+  scrollbar-width: none;
+  &::-webkit-scrollbar { display: none; }
+}
+
+.category-row {
+  display: flex;
+  gap: 8px;
+  width: max-content;
+}
+
+ion-chip {
+  --background: var(--wavely-surface-variant);
+  --color: var(--wavely-on-surface);
+  font-size: 13px;
+  transition: background 0.15s, color 0.15s;
+
+  &.selected {
+    --background: var(--chip-color, var(--wavely-primary));
+    --color: #fff;
+  }
+}
+
+.podcast-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  padding: 16px;
+}
+
+.state-message {
+  padding: 48px 32px;
+  text-align: center;
+  ion-text p { font-size: 15px; line-height: 1.5; }
+}

--- a/src/app/features/browse/browse.page.ts
+++ b/src/app/features/browse/browse.page.ts
@@ -1,15 +1,121 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { NgFor, NgIf } from '@angular/common';
 import {
   IonHeader,
   IonToolbar,
   IonTitle,
   IonContent,
+  IonChip,
+  IonLabel,
+  IonText,
 } from '@ionic/angular/standalone';
+import { Subject, switchMap, catchError, of, takeUntil, tap } from 'rxjs';
+import { PodcastCardComponent } from '../../shared/components/podcast-card/podcast-card.component';
+import { PodcastApiService } from '../../core/services/podcast-api.service';
+import { Podcast } from '../../core/models/podcast.model';
+
+export interface PodcastCategory {
+  id: number;
+  name: string;
+  color: string;
+}
+
+export const PODCAST_CATEGORIES: PodcastCategory[] = [
+  { id: 0,    name: 'All',         color: '#1A73E8' },
+  { id: 1489, name: 'News',        color: '#EA4335' },
+  { id: 1304, name: 'Education',   color: '#34A853' },
+  { id: 1303, name: 'Comedy',      color: '#FBBC04' },
+  { id: 1301, name: 'Arts',        color: '#9C27B0' },
+  { id: 1307, name: 'Science',     color: '#00ACC1' },
+  { id: 1318, name: 'Technology',  color: '#FF5722' },
+  { id: 1321, name: 'Business',    color: '#607D8B' },
+  { id: 1309, name: 'TV & Film',   color: '#3F51B5' },
+  { id: 1310, name: 'Music',       color: '#4CAF50' },
+  { id: 1323, name: 'Sports',      color: '#FF9800' },
+  { id: 1324, name: 'True Crime',  color: '#424242' },
+];
+
+const SKELETON_COUNT = 6;
 
 @Component({
   selector: 'wavely-browse',
   templateUrl: './browse.page.html',
   styleUrls: ['./browse.page.scss'],
-  imports: [IonHeader, IonToolbar, IonTitle, IonContent],
+  imports: [
+    NgFor,
+    NgIf,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonChip,
+    IonLabel,
+    IonText,
+    PodcastCardComponent,
+  ],
 })
-export class BrowsePage {}
+export class BrowsePage implements OnDestroy {
+  private readonly api = inject(PodcastApiService);
+  private readonly router = inject(Router);
+
+  protected readonly categories = PODCAST_CATEGORIES;
+  protected readonly skeletons = Array.from({ length: SKELETON_COUNT });
+  protected readonly skeletonPodcast: Podcast = {
+    id: '', title: '', author: '', description: '', artworkUrl: '', feedUrl: '', genres: [],
+  };
+
+  protected selectedCategory = PODCAST_CATEGORIES[0];
+  protected topPodcasts: Podcast[] = [];
+  protected isLoading = false;
+  protected error: string | null = null;
+
+  private readonly category$ = new Subject<PodcastCategory>();
+  private readonly destroy$ = new Subject<void>();
+
+  constructor() {
+    // switchMap cancels the previous in-flight request on each new category emission
+    this.category$
+      .pipe(
+        tap(() => {
+          this.isLoading = true;
+          this.error = null;
+          this.topPodcasts = [];
+        }),
+        switchMap((cat) => {
+          const obs$ = cat.id === 0
+            ? this.api.getTrendingPodcasts(25)
+            : this.api.getTrendingPodcasts(25, cat.id);
+          return obs$.pipe(
+            catchError(() => {
+              this.error = 'Could not load podcasts. Please try again.';
+              return of([] as Podcast[]);
+            }),
+          );
+        }),
+        takeUntil(this.destroy$),
+      )
+      .subscribe((podcasts) => {
+        this.topPodcasts = podcasts;
+        this.isLoading = false;
+      });
+
+    // Load initial category
+    this.category$.next(this.selectedCategory);
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  protected selectCategory(category: PodcastCategory): void {
+    if (this.selectedCategory.id === category.id) return;
+    this.selectedCategory = category;
+    this.category$.next(category);
+  }
+
+  protected navigateToPodcast(podcast: Podcast): void {
+    this.router.navigate(['/podcast', podcast.id]);
+  }
+}


### PR DESCRIPTION
Implements Browse page (closes #4). Category chips with switchMap pipeline to cancel stale requests on rapid switching. Reviewer finding fixed: stale-response race replaced with Subject+switchMap pattern.