### PR TITLE
feat(library): Library page — subscriptions list with swipe-to-unsubscribe

### DIFF
--- a/src/app/features/library/library.page.html
+++ b/src/app/features/library/library.page.html
@@ -1,8 +1,68 @@
 <ion-header>
   <ion-toolbar>
     <ion-title>Library</ion-title>
+    <ion-buttons slot="end">
+      <ion-button (click)="navigateToBrowse()" aria-label="Add podcasts">
+        <ion-icon slot="icon-only" name="add-outline"></ion-icon>
+      </ion-button>
+    </ion-buttons>
   </ion-toolbar>
 </ion-header>
-<ion-content class="ion-padding">
-  <!-- Library content -->
+
+<ion-content>
+  <!-- Subscriptions list -->
+  <ng-container *ngIf="store.subscriptions().length > 0; else emptyState">
+    <p class="list-hint">Swipe left to unsubscribe</p>
+    <ion-list lines="full">
+      <ion-item-sliding
+        *ngFor="let podcast of store.subscriptions()"
+        #slidingItem>
+
+        <ion-item
+          button
+          detail="true"
+          (click)="navigateToPodcast(podcast)">
+          <ion-avatar slot="start" class="podcast-avatar">
+            <img
+              [src]="podcast.artworkUrl || '/default-artwork.svg'"
+              [alt]="podcast.title"
+              (error)="onImageError($event)" />
+          </ion-avatar>
+          <ion-label>
+            <h2>{{ podcast.title }}</h2>
+            <ion-note>{{ podcast.author }}</ion-note>
+          </ion-label>
+          <!-- Always-visible unsubscribe for keyboard/a11y users -->
+          <ion-button
+            slot="end"
+            fill="clear"
+            color="medium"
+            size="small"
+            [attr.aria-label]="'Unsubscribe from ' + podcast.title"
+            (click)="$event.stopPropagation(); unsubscribe(podcast, slidingItem)">
+            ✕
+          </ion-button>
+        </ion-item>
+
+        <ion-item-options side="end">
+          <ion-item-option color="danger" (click)="unsubscribe(podcast, slidingItem)">
+            Unsubscribe
+          </ion-item-option>
+        </ion-item-options>
+      </ion-item-sliding>
+    </ion-list>
+  </ng-container>
+
+  <!-- Empty state -->
+  <ng-template #emptyState>
+    <div class="empty-state">
+      <ion-text color="medium">
+        <p class="empty-state__title">No subscriptions yet</p>
+        <p class="empty-state__sub">Browse podcasts and subscribe to build your library.</p>
+      </ion-text>
+      <ion-button (click)="navigateToBrowse()" fill="solid" color="primary">
+        Browse Podcasts
+      </ion-button>
+    </div>
+  </ng-template>
 </ion-content>

--- a/src/app/features/library/library.page.scss
+++ b/src/app/features/library/library.page.scss
@@ -1,0 +1,57 @@
+.list-hint {
+  margin: 12px 16px 4px;
+  font-size: 12px;
+  color: var(--wavely-on-surface-muted);
+}
+
+.podcast-avatar {
+  --size: 52px;
+  width: var(--size);
+  height: var(--size);
+  border-radius: 8px;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+ion-label h2 {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--wavely-on-surface);
+}
+
+ion-note {
+  font-size: 12px;
+  color: var(--wavely-on-surface-muted);
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 64px 32px;
+  text-align: center;
+  gap: 16px;
+
+  &__title {
+    font-size: 18px;
+    font-weight: 600;
+    margin: 0 0 4px;
+    color: var(--wavely-on-surface);
+  }
+
+  &__sub {
+    font-size: 14px;
+    line-height: 1.5;
+    margin: 0;
+  }
+
+  ion-button {
+    margin-top: 8px;
+  }
+}

--- a/src/app/features/library/library.page.ts
+++ b/src/app/features/library/library.page.ts
@@ -1,15 +1,77 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { NgFor, NgIf } from '@angular/common';
 import {
   IonHeader,
   IonToolbar,
   IonTitle,
   IonContent,
+  IonList,
+  IonItem,
+  IonItemSliding,
+  IonItemOptions,
+  IonItemOption,
+  IonAvatar,
+  IonLabel,
+  IonNote,
+  IonText,
+  IonButtons,
+  IonButton,
+  IonIcon,
 } from '@ionic/angular/standalone';
+import { addIcons } from 'ionicons';
+import { addOutline } from 'ionicons/icons';
+import { PodcastsStore } from '../../store/podcasts/podcasts.store';
+import { Podcast } from '../../core/models/podcast.model';
 
 @Component({
   selector: 'wavely-library',
   templateUrl: './library.page.html',
   styleUrls: ['./library.page.scss'],
-  imports: [IonHeader, IonToolbar, IonTitle, IonContent],
+  imports: [
+    NgFor,
+    NgIf,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonList,
+    IonItem,
+    IonItemSliding,
+    IonItemOptions,
+    IonItemOption,
+    IonAvatar,
+    IonLabel,
+    IonNote,
+    IonText,
+    IonButtons,
+    IonButton,
+    IonIcon,
+  ],
 })
-export class LibraryPage {}
+export class LibraryPage {
+  protected readonly store = inject(PodcastsStore);
+  private readonly router = inject(Router);
+
+  constructor() {
+    addIcons({ addOutline });
+  }
+
+  protected navigateToPodcast(podcast: Podcast): void {
+    this.router.navigate(['/podcast', podcast.id]);
+  }
+
+  protected navigateToBrowse(): void {
+    this.router.navigate(['/tabs/browse']);
+  }
+
+  protected unsubscribe(podcast: Podcast, slidingItem: IonItemSliding): void {
+    slidingItem.close();
+    this.store.removeSubscription(podcast.id);
+  }
+
+  protected onImageError(event: Event): void {
+    const img = event.target as HTMLImageElement;
+    img.src = '/default-artwork.svg';
+  }
+}


### PR DESCRIPTION
Implements Library page (closes #5). IonItemSliding swipe-to-unsubscribe + always-visible X button for a11y. Empty state with Browse CTA. Reviewer finding fixed: added keyboard-accessible unsubscribe control alongside swipe gesture.