### PR TITLE
feat(podcast-detail): Podcast detail page with episode list

### DIFF
--- a/src/app/core/services/podcast-api.service.ts
+++ b/src/app/core/services/podcast-api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, map } from 'rxjs';
-import { Podcast } from '../models/podcast.model';
+import { Podcast, Episode } from '../models/podcast.model';
 
 // Uses iTunes Search API (no key required) as primary data source.
 @Injectable({ providedIn: 'root' })
@@ -31,7 +31,6 @@ export class PodcastApiService {
    * Fetch top podcasts chart via the iTunes RSS feed.
    * @param limit Number of results (max 100). Default 25.
    * @param genreId Optional iTunes genre ID. Omit for overall top chart.
-   * Endpoint: https://itunes.apple.com/us/rss/toppodcasts/limit=N/genre/ID/json
    */
   getTrendingPodcasts(limit = 25, genreId?: number): Observable<Podcast[]> {
     const genrePath = genreId ? `/genre/${genreId}` : '';
@@ -41,12 +40,32 @@ export class PodcastApiService {
       .pipe(map((feed) => feed.feed.entry.map(this.mapRssEntry)));
   }
 
+  /**
+   * Fetch episodes for a podcast via iTunes lookup.
+   * Returns up to `limit` most recent episodes.
+   */
+  getPodcastEpisodes(itunesId: string, limit = 50): Observable<Episode[]> {
+    const params = new HttpParams()
+      .set('id', itunesId)
+      .set('entity', 'podcastEpisode')
+      .set('limit', String(limit));
+    return this.http
+      .get<{ results: ItunesEpisodeRaw[] }>(`${this.itunesBase}/lookup`, { params })
+      .pipe(
+        map((res) =>
+          res.results
+            .filter((r) => r.kind === 'podcast-episode')
+            .map(this.mapItunesEpisode)
+        ),
+      );
+  }
+
   private mapItunesPodcast(raw: ItunesPodcast): Podcast {
     return {
       id: String(raw.collectionId),
       title: raw.collectionName,
       author: raw.artistName,
-      description: '',
+      description: raw.collectionCensoredName ?? '',
       artworkUrl: raw.artworkUrl600 ?? raw.artworkUrl100,
       feedUrl: raw.feedUrl ?? '',
       genres: raw.genres ?? [],
@@ -56,7 +75,6 @@ export class PodcastApiService {
   }
 
   private mapRssEntry(entry: ItunesRssEntry): Podcast {
-    // Artwork comes as 55x55 / 60x60 / 170x170 — take last (largest) and upscale URL
     const artworkUrl = (entry['im:image']?.at(-1)?.label ?? '')
       .replace(/\/\d+x\d+bb\./, '/600x600bb.');
     const genreAttr = entry.category?.attributes;
@@ -70,11 +88,25 @@ export class PodcastApiService {
       genres: genreAttr?.label ? [genreAttr.label] : [],
     };
   }
+
+  private mapItunesEpisode(raw: ItunesEpisodeRaw): Episode {
+    return {
+      id: String(raw.trackId),
+      podcastId: String(raw.collectionId),
+      title: raw.trackName,
+      description: raw.description ?? '',
+      audioUrl: raw.previewUrl ?? '',
+      imageUrl: raw.artworkUrl600 ?? raw.artworkUrl160,
+      duration: Math.round((raw.trackTimeMillis ?? 0) / 1000),
+      releaseDate: raw.releaseDate,
+    };
+  }
 }
 
 interface ItunesPodcast {
   collectionId: number;
   collectionName: string;
+  collectionCensoredName?: string;
   artistName: string;
   artworkUrl600: string;
   artworkUrl100: string;
@@ -95,4 +127,17 @@ interface ItunesRssEntry {
 
 interface ItunesRssFeed {
   feed: { entry: ItunesRssEntry[] };
+}
+
+interface ItunesEpisodeRaw {
+  kind: string;
+  trackId: number;
+  collectionId: number;
+  trackName: string;
+  description?: string;
+  previewUrl?: string;
+  artworkUrl600?: string;
+  artworkUrl160?: string;
+  trackTimeMillis?: number;
+  releaseDate: string;
 }

--- a/src/app/features/podcast-detail/podcast-detail.page.html
+++ b/src/app/features/podcast-detail/podcast-detail.page.html
@@ -1,8 +1,94 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>Podcast</ion-title>
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="/tabs/home"></ion-back-button>
+    </ion-buttons>
+    <ion-title>{{ podcast?.title || '' }}</ion-title>
   </ion-toolbar>
 </ion-header>
-<ion-content class="ion-padding">
-  <!-- Podcast content -->
+
+<ion-content>
+  <!-- Loading skeleton -->
+  <ng-container *ngIf="isLoading">
+    <div class="podcast-header skeleton-header">
+      <div class="skeleton-artwork"></div>
+      <div class="skeleton-meta">
+        <ion-skeleton-text animated style="width:70%; height:20px; margin-bottom:8px"></ion-skeleton-text>
+        <ion-skeleton-text animated style="width:50%; height:14px; margin-bottom:12px"></ion-skeleton-text>
+        <ion-skeleton-text animated style="width:120px; height:36px; border-radius:18px"></ion-skeleton-text>
+      </div>
+    </div>
+    <ion-list>
+      <ion-item *ngFor="let s of [1,2,3,4,5,6,7,8]">
+        <ion-label>
+          <ion-skeleton-text animated style="width:80%; height:14px; margin-bottom:6px"></ion-skeleton-text>
+          <ion-skeleton-text animated style="width:40%; height:12px"></ion-skeleton-text>
+        </ion-label>
+      </ion-item>
+    </ion-list>
+  </ng-container>
+
+  <!-- Error: podcast metadata failed -->
+  <div *ngIf="podcastError && !isLoading" class="state-message">
+    <ion-text color="medium"><p>{{ podcastError }}</p></ion-text>
+  </div>
+
+  <!-- Content -->
+  <ng-container *ngIf="!isLoading && podcast">
+    <!-- Podcast header -->
+    <div class="podcast-header">
+      <img
+        class="podcast-artwork"
+        [src]="podcast.artworkUrl || '/default-artwork.svg'"
+        [alt]="podcast.title"
+        (error)="onImageError($event)" />
+      <div class="podcast-meta">
+        <h1 class="podcast-title">{{ podcast.title }}</h1>
+        <p class="podcast-author">{{ podcast.author }}</p>
+        <p *ngIf="podcast.episodeCount" class="podcast-count">
+          {{ podcast.episodeCount }} episodes
+        </p>
+        <ion-button
+          [fill]="isSubscribed ? 'solid' : 'outline'"
+          [color]="isSubscribed ? 'primary' : 'medium'"
+          size="small"
+          shape="round"
+          (click)="toggleSubscription()">
+          <ion-icon
+            slot="start"
+            [name]="isSubscribed ? 'checkmark-circle' : 'add-circle-outline'">
+          </ion-icon>
+          {{ isSubscribed ? 'Subscribed' : 'Subscribe' }}
+        </ion-button>
+      </div>
+    </div>
+
+    <!-- Episodes error (episodes can fail independently) -->
+    <div *ngIf="episodesError" class="state-message">
+      <ion-text color="medium"><p>{{ episodesError }}</p></ion-text>
+    </div>
+
+    <!-- Episodes -->
+    <h2 class="section-title" *ngIf="episodes.length > 0">Episodes</h2>
+    <ion-list lines="full" *ngIf="episodes.length > 0">
+      <ion-item
+        *ngFor="let episode of episodes"
+        button
+        [attr.aria-label]="'Play ' + episode.title"
+        (click)="playEpisode(episode)">
+        <ion-icon name="play-circle-outline" slot="start" class="play-icon" aria-hidden="true"></ion-icon>
+        <ion-label>
+          <h3 class="episode-title">{{ episode.title }}</h3>
+          <ion-note class="episode-meta">
+            {{ episode.releaseDate | date:'mediumDate' }}
+            <span *ngIf="episode.duration"> · {{ formatDuration(episode.duration) }}</span>
+          </ion-note>
+        </ion-label>
+      </ion-item>
+    </ion-list>
+
+    <div *ngIf="episodes.length === 0 && !episodesError" class="state-message">
+      <ion-text color="medium"><p>No episodes available.</p></ion-text>
+    </div>
+  </ng-container>
 </ion-content>

--- a/src/app/features/podcast-detail/podcast-detail.page.scss
+++ b/src/app/features/podcast-detail/podcast-detail.page.scss
@@ -1,0 +1,97 @@
+.podcast-header {
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+  align-items: flex-start;
+}
+
+.podcast-artwork {
+  width: 120px;
+  height: 120px;
+  border-radius: 12px;
+  object-fit: cover;
+  flex-shrink: 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.podcast-meta {
+  flex: 1;
+  min-width: 0;
+}
+
+.podcast-title {
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0 0 4px;
+  color: var(--ion-color-dark);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.podcast-author {
+  font-size: 0.85rem;
+  color: var(--ion-color-medium);
+  margin: 0 0 4px;
+}
+
+.podcast-count {
+  font-size: 0.75rem;
+  color: var(--ion-color-medium);
+  margin: 0 0 12px;
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 700;
+  padding: 0 16px 8px;
+  color: var(--ion-color-dark);
+  margin: 0;
+}
+
+.episode-title {
+  font-size: 0.9rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.episode-meta {
+  font-size: 0.75rem;
+  color: var(--ion-color-medium);
+}
+
+.play-icon {
+  color: var(--ion-color-primary);
+  font-size: 1.8rem;
+}
+
+.state-message {
+  text-align: center;
+  padding: 32px 24px;
+
+  p {
+    color: var(--ion-color-medium);
+  }
+}
+
+.skeleton-header {
+  display: flex;
+  gap: 16px;
+  padding: 16px;
+}
+
+.skeleton-artwork {
+  width: 120px;
+  height: 120px;
+  border-radius: 12px;
+  background: var(--ion-color-light);
+  flex-shrink: 0;
+}
+
+.skeleton-meta {
+  flex: 1;
+  padding-top: 4px;
+}

--- a/src/app/features/podcast-detail/podcast-detail.page.ts
+++ b/src/app/features/podcast-detail/podcast-detail.page.ts
@@ -1,15 +1,143 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { DatePipe, NgFor, NgIf } from '@angular/common';
 import {
   IonHeader,
   IonToolbar,
   IonTitle,
   IonContent,
+  IonButtons,
+  IonBackButton,
+  IonButton,
+  IonIcon,
+  IonList,
+  IonItem,
+  IonLabel,
+  IonNote,
+  IonSkeletonText,
+  IonText,
 } from '@ionic/angular/standalone';
+import { addIcons } from 'ionicons';
+import { checkmarkCircle, addCircleOutline, playCircleOutline } from 'ionicons/icons';
+import { PodcastApiService } from '../../core/services/podcast-api.service';
+import { PodcastsStore } from '../../store/podcasts/podcasts.store';
+import { PlayerStore } from '../../store/player/player.store';
+import { Podcast, Episode } from '../../core/models/podcast.model';
+import { catchError, forkJoin, of } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'wavely-podcast-detail',
   templateUrl: './podcast-detail.page.html',
   styleUrls: ['./podcast-detail.page.scss'],
-  imports: [IonHeader, IonToolbar, IonTitle, IonContent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DatePipe,
+    NgFor,
+    NgIf,
+    IonHeader,
+    IonToolbar,
+    IonTitle,
+    IonContent,
+    IonButtons,
+    IonBackButton,
+    IonButton,
+    IonIcon,
+    IonList,
+    IonItem,
+    IonLabel,
+    IonNote,
+    IonSkeletonText,
+    IonText,
+  ],
 })
-export class PodcastDetailPage {}
+export class PodcastDetailPage {
+  private readonly route = inject(ActivatedRoute);
+  private readonly api = inject(PodcastApiService);
+  private readonly destroyRef = inject(DestroyRef);
+  protected readonly podcastsStore = inject(PodcastsStore);
+  protected readonly playerStore = inject(PlayerStore);
+
+  protected podcast: Podcast | null = null;
+  protected episodes: Episode[] = [];
+  protected isLoading = true;
+  protected episodesError: string | null = null;
+  protected podcastError: string | null = null;
+
+  constructor() {
+    addIcons({ checkmarkCircle, addCircleOutline, playCircleOutline });
+
+    // Stream driven from route params — survives reuse; auto-unsubscribes on destroy
+    this.route.paramMap
+      .pipe(
+        switchMap((params) => {
+          const id = params.get('id') ?? '';
+          this.isLoading = true;
+          this.podcast = null;
+          this.episodes = [];
+          this.episodesError = null;
+          this.podcastError = null;
+          return forkJoin({
+            podcast: this.api.lookupPodcast(id).pipe(
+              catchError(() => {
+                this.podcastError = 'Could not load podcast info.';
+                return of(null);
+              }),
+            ),
+            episodes: this.api.getPodcastEpisodes(id, 50).pipe(
+              catchError(() => {
+                this.episodesError = 'Could not load episodes.';
+                return of([] as Episode[]);
+              }),
+            ),
+          });
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(({ podcast, episodes }) => {
+        this.podcast = podcast;
+        this.episodes = episodes;
+        this.isLoading = false;
+      });
+  }
+
+  protected get isSubscribed(): boolean {
+    return this.podcast
+      ? this.podcastsStore.subscriptions().some((p) => p.id === this.podcast!.id)
+      : false;
+  }
+
+  protected toggleSubscription(): void {
+    if (!this.podcast) return;
+    if (this.isSubscribed) {
+      this.podcastsStore.removeSubscription(this.podcast.id);
+    } else {
+      this.podcastsStore.addSubscription(this.podcast);
+    }
+  }
+
+  protected playEpisode(episode: Episode): void {
+    if (!this.podcast) return;
+    // Set the clicked episode as current, queue the rest that follow it
+    const idx = this.episodes.findIndex((e) => e.id === episode.id);
+    const upcoming = this.episodes.slice(idx + 1);
+    this.playerStore.clearQueue();
+    upcoming.forEach((e) => this.playerStore.addToQueue(e));
+    this.playerStore.play(episode);
+  }
+
+  protected formatDuration(seconds: number): string {
+    if (!seconds) return '';
+    const h = Math.floor(seconds / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = seconds % 60;
+    if (h > 0) return `${h}h ${m}m`;
+    if (m > 0) return `${m}m ${s > 0 ? s + 's' : ''}`.trim();
+    return `${s}s`;
+  }
+
+  protected onImageError(event: Event): void {
+    (event.target as HTMLImageElement).src = '/default-artwork.svg';
+  }
+}


### PR DESCRIPTION
## Summary

Implements issue #6 — Podcast Detail Page.

### Changes
- **PodcastApiService**: Added `getPodcastEpisodes(id, limit)` using iTunes lookup with `entity=podcastEpisode`. Added `ItunesEpisodeRaw` interface and `mapItunesEpisode()` private mapper.
- **PodcastDetailPage**: Full implementation with:
  - Route-param driven loading (`paramMap + switchMap + takeUntilDestroyed`) — no memory leaks, handles component reuse
  - Partial failure tolerance: podcast metadata and episodes fail independently with separate error messages
  - Subscribe/Unsubscribe toggle using `PodcastsStore`
  - Episode play + automatic queue setup via `PlayerStore`
  - Skeleton loading state, empty state, error states
  - `OnPush` change detection
  - Accessibility: `aria-label` on play items, `aria-hidden` on decorative icon

### Reviewer findings addressed
- Memory leak: raw `forkJoin.subscribe()` replaced with `paramMap + switchMap + takeUntilDestroyed(DestroyRef)`
- Fragile error handling: `catchError` per stream inside `forkJoin` — podcast and episodes error independently
- Accessibility: `aria-label='Play <title>'` on each episode row

Closes #6