### PR TITLE
feat(pwa): Progressive Web App with service worker and web manifest

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@angular/platform-browser-dynamic": "~21.2.0",
         "@angular/platform-server": "~21.2.0",
         "@angular/router": "~21.2.0",
+        "@angular/service-worker": "^21.2.3",
         "@angular/ssr": "~21.2.0",
         "@capacitor/app": "^8.0.1",
         "@capacitor/core": "^8.2.0",
@@ -161,6 +162,8 @@
     "@angular/platform-server": ["@angular/platform-server@21.2.3", "", { "dependencies": { "tslib": "^2.3.0", "xhr2": "^0.2.0" }, "peerDependencies": { "@angular/common": "21.2.3", "@angular/compiler": "21.2.3", "@angular/core": "21.2.3", "@angular/platform-browser": "21.2.3", "rxjs": "^6.5.3 || ^7.4.0" } }, "sha512-2Pflo9k8hFjDETyI0SMVYrY+gRUZCJLPCVAQhrazMD1TbK8U52jRIOv28BlQwBbZAVRI5DG2ek6h43BgGz1GVg=="],
 
     "@angular/router": ["@angular/router@21.2.3", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/common": "21.2.3", "@angular/core": "21.2.3", "@angular/platform-browser": "21.2.3", "rxjs": "^6.5.3 || ^7.4.0" } }, "sha512-vSQovp+3u7HDn/nbKRIUEtY5ztCuyX2t2gQKGhYeXhelETJXaLWOoRntXZ0s95l0harGxFUU1pnCX8mqsrVFbw=="],
+
+    "@angular/service-worker": ["@angular/service-worker@21.2.3", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/core": "21.2.3", "rxjs": "^6.5.3 || ^7.4.0" }, "bin": { "ngsw-config": "ngsw-config.js" } }, "sha512-U6fAnyXIRFcQXDG+9RzYtSl4G7rscjY3WbRhNsga/yKhdDkCzSh1cAwkm+YyYIlCx2WFPNkDzwzMnA9Y+zFbxg=="],
 
     "@angular/ssr": ["@angular/ssr@21.2.2", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/common": "^21.0.0", "@angular/core": "^21.0.0", "@angular/platform-server": "^21.0.0", "@angular/router": "^21.0.0" }, "optionalPeers": ["@angular/platform-server"] }, "sha512-ZEdE0G3+v0JCtSxpBynSlGImXi47HwWGqANtfHcOJUdf6GGKzSzoyliT1+7Lu2TR4TyCjtDq/RQH5bETr3zghA=="],
 

--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "./node_modules/@angular/service-worker/config/schema.json",
+  "index": "/index.html",
+  "assetGroups": [
+    {
+      "name": "app-shell",
+      "installMode": "prefetch",
+      "resources": {
+        "files": [
+          "/favicon.ico",
+          "/index.html",
+          "/manifest.webmanifest",
+          "/*.css",
+          "/*.js"
+        ]
+      }
+    },
+    {
+      "name": "assets",
+      "installMode": "lazy",
+      "updateMode": "prefetch",
+      "resources": {
+        "files": [
+          "/assets/**",
+          "/icons/**",
+          "/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)"
+        ]
+      }
+    }
+  ],
+  "dataGroups": [
+    {
+      "name": "itunes-api",
+      "urls": [
+        "https://itunes.apple.com/**"
+      ],
+      "cacheConfig": {
+        "maxSize": 100,
+        "maxAge": "1h",
+        "timeout": "10s",
+        "strategy": "freshness"
+      }
+    },
+    {
+      "name": "podcast-artwork",
+      "urls": [
+        "https://*.mzstatic.com/**",
+        "https://is*.mzstatic.com/**"
+      ],
+      "cacheConfig": {
+        "maxSize": 200,
+        "maxAge": "7d",
+        "strategy": "performance"
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@angular/platform-browser-dynamic": "~21.2.0",
     "@angular/platform-server": "~21.2.0",
     "@angular/router": "~21.2.0",
+    "@angular/service-worker": "^21.2.3",
     "@angular/ssr": "~21.2.0",
     "@capacitor/app": "^8.0.1",
     "@capacitor/core": "^8.2.0",

--- a/project.json
+++ b/project.json
@@ -19,6 +19,11 @@
           {
             "glob": "**/*",
             "input": "public"
+          },
+          {
+            "glob": "manifest.webmanifest",
+            "input": "src",
+            "output": "/"
           }
         ],
         "styles": ["./src/styles.scss"],
@@ -42,7 +47,8 @@
               "maximumError": "8kb"
             }
           ],
-          "outputHashing": "all"
+          "outputHashing": "all",
+          "serviceWorker": "ngsw-config.json"
         },
         "development": {
           "optimization": false,

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,10 +1,12 @@
 import {
   ApplicationConfig,
+  isDevMode,
   provideBrowserGlobalErrorListeners,
 } from '@angular/core';
 import { provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
 import { provideHttpClient, withFetch } from '@angular/common/http';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
+import { provideServiceWorker } from '@angular/service-worker';
 import { provideIonicAngular } from '@ionic/angular/standalone';
 import { appRoutes } from './app.routes';
 
@@ -17,6 +19,10 @@ export const appConfig: ApplicationConfig = {
     provideIonicAngular({
       mode: 'md',
       animated: true,
+    }),
+    provideServiceWorker('ngsw-worker.js', {
+      enabled: !isDevMode(),
+      registrationStrategy: 'registerWhenStable:30000',
     }),
   ],
 };

--- a/src/index.html
+++ b/src/index.html
@@ -2,10 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>wavely</title>
+    <title>Wavely</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Wavely — Discover and listen to your favourite podcasts" />
+    <meta name="theme-color" content="#1A73E8" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="manifest" href="manifest.webmanifest" />
+    <link rel="apple-touch-icon" href="icons/icon-192x192.png" />
   </head>
   <body>
     <app-root></app-root>

--- a/src/manifest.webmanifest
+++ b/src/manifest.webmanifest
@@ -1,0 +1,60 @@
+{
+  "name": "Wavely",
+  "short_name": "Wavely",
+  "description": "Discover and listen to your favourite podcasts",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#F8F9FA",
+  "theme_color": "#1A73E8",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "icons/icon-72x72.png",
+      "sizes": "72x72",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "icons/icon-96x96.png",
+      "sizes": "96x96",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "icons/icon-128x128.png",
+      "sizes": "128x128",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "icons/icon-144x144.png",
+      "sizes": "144x144",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "icons/icon-152x152.png",
+      "sizes": "152x152",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "icons/icon-384x384.png",
+      "sizes": "384x384",
+      "type": "image/png",
+      "purpose": "maskable any"
+    },
+    {
+      "src": "icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable any"
+    }
+  ]
+}

--- a/src/ngsw-config.json
+++ b/src/ngsw-config.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "./node_modules/@angular/service-worker/config/schema.json",
+  "index": "/index.html",
+  "assetGroups": [
+    {
+      "name": "app-shell",
+      "installMode": "prefetch",
+      "resources": {
+        "files": [
+          "/favicon.ico",
+          "/index.html",
+          "/manifest.webmanifest",
+          "/*.css",
+          "/*.js"
+        ]
+      }
+    },
+    {
+      "name": "assets",
+      "installMode": "lazy",
+      "updateMode": "prefetch",
+      "resources": {
+        "files": [
+          "/assets/**",
+          "/icons/**",
+          "/*.(svg|cur|jpg|jpeg|png|apng|webp|avif|gif|otf|ttf|woff|woff2)"
+        ]
+      }
+    }
+  ],
+  "dataGroups": [
+    {
+      "name": "itunes-api",
+      "urls": [
+        "https://itunes.apple.com/**"
+      ],
+      "cacheConfig": {
+        "maxSize": 100,
+        "maxAge": "1h",
+        "timeout": "10s",
+        "strategy": "freshness"
+      }
+    },
+    {
+      "name": "podcast-artwork",
+      "urls": [
+        "https://*.mzstatic.com/**",
+        "https://is*.mzstatic.com/**"
+      ],
+      "cacheConfig": {
+        "maxSize": 200,
+        "maxAge": "7d",
+        "strategy": "performance"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements issue #12 — PWA/Offline support.

### What's included

**`@angular/service-worker` installed** (21.2.3)

**`ngsw-config.json`** service worker caching strategy:
- `app-shell` (prefetch): HTML, CSS, JS — instant load on repeat visits
- `assets` (lazy/prefetch on update): SVGs, images, fonts
- `itunes-api` data group: 1h freshness cache for iTunes API calls — works offline for recently browsed content
- `podcast-artwork` data group: 7-day performance cache for artwork URLs from mzstatic.com

**`manifest.webmanifest`**: installable PWA — name, icons (72px to 512px), standalone display, brand colors

**`index.html`**: manifest link, `theme-color` meta, `apple-touch-icon`

**`app.config.ts`**: `provideServiceWorker()` —

**`project.json`**:
- `serviceWorker` build option pointing to `ngsw-config.json`
- `manifest.webmanifest` added to assets

### Verified
`dist/wavely/browser/` contains: `ngsw-worker.js`, `ngsw.json`, `safety-worker.js`, `manifest.webmanifest`

Closes #12