### PR TITLE
feat(progress): playback progress persistence with Firestore

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -29,10 +29,17 @@ jobs:
           NG_APP_FIREBASE_APP_ID: ${{ secrets.NG_APP_FIREBASE_APP_ID }}
           NG_APP_FIREBASE_MEASUREMENT_ID: ${{ secrets.NG_APP_FIREBASE_MEASUREMENT_ID }}
 
-      - name: Deploy to Firebase Hosting
+      - name: Deploy to Firebase Hosting + Firestore Rules
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_WAVELY_F659C }}
           channelId: live
           projectId: wavely-f659c
+          target: hosting
+          entryPoint: .
+
+      - name: Deploy Firestore Rules
+        run: bunx firebase deploy --only firestore:rules --project wavely-f659c
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/firebase.json
+++ b/firebase.json
@@ -23,5 +23,8 @@
         ]
       }
     ]
+  },
+  "firestore": {
+    "rules": "firestore.rules"
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,26 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // User-owned subcollections: only the authenticated user can read/write their own data
+    match /users/{uid}/{document=**} {
+      allow read, write: if request.auth != null && request.auth.uid == uid;
+    }
+
+    // Public podcast/episode metadata cache (read-only for authenticated users)
+    match /podcasts/{podcastId} {
+      allow read: if request.auth != null;
+      allow write: if false; // only written server-side
+    }
+
+    match /episodes/{episodeId} {
+      allow read: if request.auth != null;
+      allow write: if false;
+    }
+
+    // Deny everything else
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/src/app/core/services/audio.service.ts
+++ b/src/app/core/services/audio.service.ts
@@ -1,6 +1,8 @@
 import { inject, Injectable, PLATFORM_ID, effect, untracked } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 import { PlayerStore } from '../../store/player/player.store';
+import { AuthStore } from '../../store/auth/auth.store';
+import { ProgressSyncService } from './progress-sync.service';
 
 /**
  * AudioService
@@ -14,6 +16,8 @@ import { PlayerStore } from '../../store/player/player.store';
 @Injectable({ providedIn: 'root' })
 export class AudioService {
   private readonly store = inject(PlayerStore);
+  private readonly authStore = inject(AuthStore);
+  private readonly progressSync = inject(ProgressSyncService);
   private readonly platformId = inject(PLATFORM_ID);
 
   private audio: HTMLAudioElement | null = null;
@@ -23,6 +27,20 @@ export class AudioService {
    * Prevents the timeupdate handler from overwriting the seek target.
    */
   private seeking = false;
+
+  /** Position fetched from Firestore, waiting to be applied once metadata loads. */
+  private pendingRestorePosition: number | null = null;
+  /** Set to true by loadedmetadata — used to decide whether to seek immediately. */
+  private metadataLoaded = false;
+
+  /**
+   * Tracks which episode is actually loaded in the HTMLAudioElement.
+   * Updated only when audio.src is set — NOT read from the store in DOM event handlers,
+   * because the store's currentEpisode() may advance to the next episode before audio.src
+   * is updated (the effect runs asynchronously), causing timeupdate to write the old
+   * timestamp under the new episode's ID.
+   */
+  private activeEpisodeId: string | null = null;
 
   constructor() {
     if (!isPlatformBrowser(this.platformId)) return;
@@ -36,11 +54,40 @@ export class AudioService {
       const episode = this.store.currentEpisode();
       untracked(() => {
         if (!this.audio) return;
-        // Reset seeking flag — a source swap cancels any in-flight seek
+        // Reset state for new episode
         this.seeking = false;
+        this.pendingRestorePosition = null;
+        this.metadataLoaded = false;
+
         if (episode) {
+          // Flush any pending progress write for the previous episode
+          this.progressSync.flush();
+
           this.audio.src = episode.audioUrl;
+          // Update activeEpisodeId AFTER setting src — DOM event handlers must use
+          // this field, not store.currentEpisode(), to avoid writing timestamps to
+          // a new episode ID before audio.src has been updated.
+          this.activeEpisodeId = episode.id;
           this.audio.load();
+
+          // Asynchronously load saved position; apply it once metadata is ready
+          const episodeId = episode.id;
+          const uid = this.authStore.user()?.uid ?? null;
+          this.progressSync.loadProgress(episodeId, uid).then((savedPosition) => {
+            // Guard: discard if the episode changed while fetch was in-flight
+            if (this.store.currentEpisode()?.id !== episodeId) return;
+            if (savedPosition <= 1) return;
+
+            if (this.metadataLoaded) {
+              // Metadata already arrived — seek immediately
+              this.seeking = true;
+              this.audio!.currentTime = savedPosition;
+            } else {
+              // Metadata not yet loaded — defer to loadedmetadata handler
+              this.pendingRestorePosition = savedPosition;
+            }
+          });
+
           // If already in "playing" state, play() after load.
           // This handles playNext() advancing to next episode while isPlaying stays true.
           if (this.store.isPlaying()) {
@@ -50,6 +97,8 @@ export class AudioService {
             });
           }
         } else {
+          this.progressSync.flush();
+          this.activeEpisodeId = null;
           this.audio.src = '';
           this.audio.load();
         }
@@ -98,18 +147,56 @@ export class AudioService {
   private wireEvents(): void {
     if (!this.audio) return;
 
+    this.audio.addEventListener('loadedmetadata', () => {
+      this.metadataLoaded = true;
+      if (this.pendingRestorePosition !== null && this.pendingRestorePosition > 1) {
+        this.seeking = true;
+        this.audio!.currentTime = this.pendingRestorePosition;
+        this.pendingRestorePosition = null;
+      }
+    });
+
     this.audio.addEventListener('timeupdate', () => {
       if (this.seeking || !this.audio) return;
       this.store.updateProgress(
         this.audio.currentTime,
         isFinite(this.audio.duration) ? this.audio.duration : 0
       );
+      // Throttled Firestore write during playback
+      const uid = this.authStore.user()?.uid ?? null;
+      // Use activeEpisodeId (not store) — store.currentEpisode() may already reflect
+      // the next episode while audio.src still plays the previous one.
+      const episodeId = this.activeEpisodeId;
+      if (episodeId) {
+        this.progressSync.scheduleWrite(
+          episodeId,
+          this.audio.currentTime,
+          isFinite(this.audio.duration) ? this.audio.duration : 0,
+          uid
+        );
+      }
     });
 
     this.audio.addEventListener('durationchange', () => {
       if (!this.audio) return;
       const dur = isFinite(this.audio.duration) ? this.audio.duration : 0;
       this.store.updateProgress(this.audio.currentTime, dur);
+    });
+
+    this.audio.addEventListener('pause', () => {
+      // Flush progress on any pause (user-initiated or programmatic).
+      // Use activeEpisodeId — same race reason as timeupdate handler.
+      const uid = this.authStore.user()?.uid ?? null;
+      const episodeId = this.activeEpisodeId;
+      if (episodeId && this.audio) {
+        this.progressSync.scheduleWrite(
+          episodeId,
+          this.audio.currentTime,
+          isFinite(this.audio.duration) ? this.audio.duration : 0,
+          uid
+        );
+        this.progressSync.flush();
+      }
     });
 
     this.audio.addEventListener('seeked', () => {
@@ -122,6 +209,12 @@ export class AudioService {
     this.audio.addEventListener('emptied', resetSeeking);
 
     this.audio.addEventListener('ended', () => {
+      const uid = this.authStore.user()?.uid ?? null;
+      const episodeId = this.activeEpisodeId;
+      const duration = this.store.duration();
+      if (episodeId) {
+        this.progressSync.markCompleted(episodeId, duration, uid);
+      }
       this.store.playNext();
     });
 

--- a/src/app/core/services/progress-sync.service.ts
+++ b/src/app/core/services/progress-sync.service.ts
@@ -1,0 +1,118 @@
+import { Injectable } from '@angular/core';
+import {
+  doc,
+  getDoc,
+  getFirestore,
+  setDoc,
+} from 'firebase/firestore';
+
+export interface EpisodeProgress {
+  episodeId: string;
+  position: number;
+  duration: number;
+  completedAt: number | null;
+  updatedAt: number;
+}
+
+/**
+ * ProgressSyncService
+ *
+ * Throttled persistence of episode playback position to Firestore.
+ * Firestore path: users/{uid}/progress/{episodeId}
+ *
+ * - Writes are throttled to every 5s during active playback
+ * - Always flushes on pause, episode change, and completion
+ * - Gracefully degrades to no-op for unauthenticated users
+ */
+@Injectable({ providedIn: 'root' })
+export class ProgressSyncService {
+  private get db() {
+    return getFirestore();
+  }
+
+  private static readonly WRITE_INTERVAL_MS = 5000;
+  private static readonly MIN_POSITION_SECONDS = 2;
+
+  private writeTimeout: ReturnType<typeof setTimeout> | null = null;
+  private pendingWrite: { episodeId: string; position: number; duration: number; uid: string } | null = null;
+  private lastWriteTime = 0;
+
+  /** Load saved position for an episode. Returns 0 if none saved. */
+  async loadProgress(episodeId: string, uid: string | null): Promise<number> {
+    if (!uid || !episodeId) return 0;
+    try {
+      const snap = await getDoc(doc(this.db, 'users', uid, 'progress', episodeId));
+      if (!snap.exists()) return 0;
+      const data = snap.data() as EpisodeProgress;
+      // Don't restore if episode was completed (within last 30s of duration)
+      if (data.completedAt) return 0;
+      return data.position ?? 0;
+    } catch (err) {
+      console.error('[ProgressSyncService] Failed to load progress', err);
+      return 0;
+    }
+  }
+
+  /**
+   * Schedule a throttled write. Writes at most every 5s during playback.
+   * Call from AudioService timeupdate handler.
+   */
+  scheduleWrite(episodeId: string, position: number, duration: number, uid: string | null): void {
+    if (!uid || !episodeId || position < ProgressSyncService.MIN_POSITION_SECONDS) return;
+
+    this.pendingWrite = { episodeId, position, duration, uid };
+
+    const elapsed = Date.now() - this.lastWriteTime;
+    if (elapsed >= ProgressSyncService.WRITE_INTERVAL_MS) {
+      this.flush();
+    } else if (!this.writeTimeout) {
+      const remaining = ProgressSyncService.WRITE_INTERVAL_MS - elapsed;
+      this.writeTimeout = setTimeout(() => this.flush(), remaining);
+    }
+  }
+
+  /** Force an immediate write of any pending progress (call on pause, episode change). */
+  async flush(): Promise<void> {
+    if (this.writeTimeout) {
+      clearTimeout(this.writeTimeout);
+      this.writeTimeout = null;
+    }
+    if (!this.pendingWrite) return;
+
+    const { episodeId, position, duration, uid } = this.pendingWrite;
+    this.pendingWrite = null;
+    this.lastWriteTime = Date.now();
+
+    try {
+      // completedAt is intentionally omitted — only markCompleted() may set it.
+      // Writing null here would clobber completion status set on another device.
+      await setDoc(
+        doc(this.db, 'users', uid, 'progress', episodeId),
+        { episodeId, position, duration, updatedAt: Date.now() },
+        { merge: true }
+      );
+    } catch (err) {
+      console.error('[ProgressSyncService] Failed to save progress', err);
+    }
+  }
+
+  /** Mark episode as fully completed. */
+  async markCompleted(episodeId: string, duration: number, uid: string | null): Promise<void> {
+    if (!uid || !episodeId) return;
+    if (this.writeTimeout) {
+      clearTimeout(this.writeTimeout);
+      this.writeTimeout = null;
+    }
+    this.pendingWrite = null;
+    this.lastWriteTime = Date.now();
+    try {
+      await setDoc(
+        doc(this.db, 'users', uid, 'progress', episodeId),
+        { episodeId, position: duration, duration, completedAt: Date.now(), updatedAt: Date.now() },
+        { merge: true }
+      );
+    } catch (err) {
+      console.error('[ProgressSyncService] Failed to mark episode completed', err);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements cross-device playback progress persistence using Firestore, with 3 adversarial-review bugs fixed before opening.

## Changes

### New: `ProgressSyncService`
- Throttled Firestore writes (`users/{uid}/progress/{episodeId}`) — max one write every 5s during playback
- Async position restore on episode load (handles metadata-before-Firestore and Firestore-before-metadata races)
- `markCompleted()` marks episodes as finished; `loadProgress()` skips restoring completed episodes

### Updated: `AudioService`
- Injects `AuthStore` + `ProgressSyncService`
- Throttled writes from `timeupdate`; flush on `pause`; `markCompleted` on `ended`
- Restores saved position via `pendingRestorePosition` / `metadataLoaded` two-phase pattern

### New: `firestore.rules`
- Owner-only access for `users/{uid}/**`
- Read-only for `podcasts/` + `episodes/` (authenticated users)
- Deny-all catch-all

### Updated: CI, `firebase.json`
- Firestore rules deployed on merge (requires `FIREBASE_TOKEN` secret)

## Bugs Fixed (adversarial review: gpt-5.3-codex + gemini-3-pro-preview)

| Bug | Fix |
|-----|-----|
| `flush()` wrote `completedAt:null`, clobbering completion set on another device | Removed `completedAt` from `flush()` payload entirely — only `markCompleted()` sets it |
| `timeupdate` read episode ID from store, which advances to next episode before `audio.src` updates | Added `activeEpisodeId` field updated only when `audio.src` is set; all DOM event handlers use this |
| `pause` fires after `ended`, creating a new pending write after `markCompleted` cleared state | Fixed as a side-effect of fix #1 — `flush()` no longer touches `completedAt`, so order doesn't matter |

## Notes
- `FIREBASE_TOKEN` secret must be set in repo secrets for Firestore rules CI deploy (`firebase login:ci` generates it)
- Closes #26