### PR TITLE
fix(infra): security rules + separate e2e server routes from prod

### DIFF
--- a/.github/skills/wavely-git-flow/SKILL.md
+++ b/.github/skills/wavely-git-flow/SKILL.md
@@ -132,4 +132,19 @@ Closes #<issue number>
 - Merge without a passing CI check
 - Skip the `dev` → `staging` → `main` promotion chain
 - Use personal branch names like `bene/fix` — use `fix/description` instead
-- Commit secrets, credentials, or `.env` files
+- **Commit secrets, credentials, API keys, or tokens — EVER** (this has caused real leaks)
+- Commit generated environment files (`src/environments/environment*.ts`) — they are gitignored on purpose
+- Hardcode Firebase config, Sentry DSN, or any API key directly in source files
+- Log or print secret values, even partially
+
+## Where Secrets Live
+
+All secrets are stored in **GitHub Actions secrets** and injected at build time via `scripts/generate-env.mjs`:
+
+| Secret | Used for |
+|--------|----------|
+| `FIREBASE_CONFIG` | Firebase web app config (apiKey, projectId, etc.) |
+| `FIREBASE_SERVICE_ACCOUNT_WAVELY` | Firebase Admin SDK (E2E global setup) |
+| `NG_APP_SENTRY_DSN` | Sentry error tracking DSN |
+
+For local dev, copy `.env.example` → `.env` and fill in values. The `.env` file is gitignored.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,28 @@
 
 <!-- nx configuration end-->
 
+## 🔒 Security — ABSOLUTE RULES (never break, no exceptions)
+
+**NEVER commit secrets, credentials, or tokens to the repository.** This has caused real leaks before.
+
+| What | Where it lives instead |
+|------|----------------------|
+| Firebase config (apiKey, projectId, etc.) | GitHub Actions secrets → `scripts/generate-env.mjs` generates env files at build time |
+| Firebase Admin SDK service account JSON | GitHub Actions secret `FIREBASE_SERVICE_ACCOUNT_WAVELY` |
+| Sentry DSN | GitHub Actions secret `NG_APP_SENTRY_DSN` |
+| API keys (Podcast Index, etc.) | GitHub Actions secrets or `.env` (gitignored) |
+| Firebase auth tokens / storage state | `e2e/.auth/` (gitignored) |
+
+**Rules for agents:**
+1. **Never hardcode** API keys, tokens, passwords, or any secret in source files
+2. **Never print or log** secret values — not even partially (no `key.substring(0,8)`)
+3. **If a file contains secrets, it must be in `.gitignore`** — verify before committing
+4. **Use `NG_APP_*` prefix** for env vars injected via `generate-env.mjs` — they are build-time only
+5. **When in doubt, use a placeholder** like `process.env.MY_SECRET` and document where to set it
+6. **Before every commit, mentally scan staged files** — if any file contains a real key/token, abort
+
+The environment files (`src/environments/environment*.ts`) are gitignored **on purpose** — they are generated at build time. Do not regenerate them with real credentials and commit them.
+
 ## Project Management
 
 - **Task tracker**: GitHub Issues on `bndF1/wavely` (NOT Linear)

--- a/project.json
+++ b/project.json
@@ -79,6 +79,10 @@
             {
               "replace": "src/environments/environment.ts",
               "with": "src/environments/environment.e2e.ts"
+            },
+            {
+              "replace": "src/app/app.routes.server.ts",
+              "with": "src/app/app.routes.server.e2e.ts"
             }
           ],
           "sourceMap": true,

--- a/src/app/app.routes.server.e2e.ts
+++ b/src/app/app.routes.server.e2e.ts
@@ -1,0 +1,30 @@
+import { RenderMode, ServerRoute } from '@angular/ssr';
+
+// E2E build server routes — extends the base routes with the e2e-auth
+// route which only exists when environment.useEmulators = true.
+export const serverRoutes: ServerRoute[] = [
+  {
+    path: 'login',
+    renderMode: RenderMode.Client,
+  },
+  {
+    path: 'e2e-auth/:token',
+    renderMode: RenderMode.Client,
+  },
+  {
+    path: 'tabs/**',
+    renderMode: RenderMode.Client,
+  },
+  {
+    path: 'podcast/:id',
+    renderMode: RenderMode.Server,
+  },
+  {
+    path: 'episode/:id',
+    renderMode: RenderMode.Server,
+  },
+  {
+    path: '**',
+    renderMode: RenderMode.Prerender,
+  },
+];


### PR DESCRIPTION
## Summary
Brings two fixes from the staging conflict resolution into `dev` properly.

## Changes
- **Security**: Add strict no-secrets rules to `AGENTS.md` and `wavely-git-flow` skill
- **SSR fix**: Create `app.routes.server.e2e.ts` with `e2e-auth/:token` (Client render mode only for e2e builds)
- **project.json**: Wire `fileReplacements` for e2e build so the e2e server routes are used when `--configuration=e2e`

## Why
`app.routes.ts` conditionally adds `e2e-auth/:token` only when `useEmulators: true`. If `app.routes.server.ts` references that route in a prod build it fails with: _server route does not match any routes defined in Angular routing_.

## Testing
- [ ] Unit tests pass
- [ ] Production build verified locally (no SSR errors)