### PR TITLE
fix(ci): use Java 21 for Firebase emulators

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,11 +25,11 @@ jobs:
         with:
           bun-version: '1.3.10'
 
-      - name: Set up Java 17
+      - name: Set up Java 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: '21'
 
       - name: Cache Firebase emulator binaries
         id: firebase-cache


### PR DESCRIPTION
## Root Cause
`firebase-tools@15` requires JDK 21+. PR #72 added `setup-java@v4` with Java 17, causing the emulators to shut down immediately with:
```
Error: firebase-tools no longer supports Java version before 21.
```
The health-check curl then waited 120s and timed out (exit code 124).

## Fix
Change `java-version: '17'` → `java-version: '21'`

## Testing
- [ ] E2E workflow_dispatch passes after this merges