### PR TITLE
fix(ci): disable Emulator UI in firebase.json

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,7 +55,6 @@ jobs:
         run: |
           bunx firebase-tools emulators:start \
             --only auth,firestore \
-            --no-ui \
             --project wavely-f659c &
           # Wait for auth emulator; first run downloads JARs (~2-4 min), cached runs start in <30s
           timeout 300 bash -c \

--- a/firebase.json
+++ b/firebase.json
@@ -35,8 +35,7 @@
       "port": 8080
     },
     "ui": {
-      "enabled": true,
-      "port": 4400
+      "enabled": false
     }
   }
 }


### PR DESCRIPTION
## Problem
firebase-tools does not support a `--no-ui` CLI flag (error: unknown option). The Emulator UI must be disabled via `firebase.json`.

## Fix
- Set `emulators.ui.enabled: false` in `firebase.json`
- Remove invalid `--no-ui` from `emulators:start` command

With the UI disabled, only auth (9099) and firestore (8080) start — no port 4400/4401 usage, no potential port conflicts.