### PR TITLE
fix(ci): correct nx command to run E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,7 +66,7 @@ jobs:
           echo "✅ Firestore emulator ready"
 
       - name: Run E2E tests (Chromium only)
-        run: bunx nx e2e --project=chromium
+        run: bunx nx run e2e:e2e
         env:
           CI: 'true'
           USE_EMULATORS: 'true'


### PR DESCRIPTION
## Problem
`bunx nx e2e --project=chromium` fails with «Cannot find project 'chromium'» — `chromium` is a Playwright browser project, not an Nx project.

## Fix
Use `bunx nx run e2e:e2e` — the Nx project is `e2e`, target is `e2e`. In CI, `isCI=true` so playwright.config.ts already limits to chromium-only.