### PR TITLE
fix(e2e): use absolute path for webServer dist dir in CI

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -27,11 +27,12 @@ export default defineConfig({
   webServer: isCI
     ? {
         // In CI: serve the pre-built e2e output (built with --configuration=e2e).
-        command:
-          'bunx serve dist/wavely/browser -p 4200 --no-clipboard --single',
+        // Use absolute path — playwright.config.ts runs from e2e/ so relative paths
+        // would resolve to e2e/dist/... which doesn't exist.
+        command: `bunx serve "${workspaceRoot}/dist/wavely/browser" -p 4200 --no-clipboard --single`,
         url: 'http://localhost:4200',
         reuseExistingServer: false,
-        timeout: 30_000,
+        timeout: 60_000,
       }
     : {
         // Local dev: use nx serve with live reload.


### PR DESCRIPTION
## Problem
`playwright.config.ts` runs from `e2e/` directory (the nx target cwd). So `bunx serve dist/wavely/browser` tries to serve `e2e/dist/wavely/browser` — which does not exist → serve silently fails → port 4200 never opens → 30s webServer timeout.

## Fix
- Use ````${workspaceRoot}/dist/wavely/browser```` (absolute path, `workspaceRoot` already imported from `@nx/devkit`)
- Increase timeout 30s → 60s as safety margin