### PR TITLE
fix(e2e): resolve auth race condition in global setup

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -48,11 +48,11 @@ async function globalSetup(config: FullConfig): Promise<void> {
   const page = await context.newPage();
 
   await page.goto(`${baseURL}/e2e-auth/${customToken}`, {
-    waitUntil: 'networkidle',
+    waitUntil: 'load',
     timeout: 30_000,
   });
 
-  await page.waitForURL(/\/tabs\/home/, { timeout: 30_000 });
+  await page.waitForURL(/\/tabs\/home/, { timeout: 60_000 });
   await context.storageState({ path: AUTH_STATE_FILE });
 
   await browser.close();

--- a/src/app/features/e2e-auth/e2e-auth.component.ts
+++ b/src/app/features/e2e-auth/e2e-auth.component.ts
@@ -1,7 +1,8 @@
 import { Component, inject, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Auth, signInWithCustomToken } from '@angular/fire/auth';
+import { Auth, signInWithCustomToken, user } from '@angular/fire/auth';
 import { IonContent } from '@ionic/angular/standalone';
+import { filter, firstValueFrom } from 'rxjs';
 
 /**
  * E2E-only route: /e2e-auth/:token
@@ -25,6 +26,10 @@ export class E2eAuthComponent implements OnInit {
   async ngOnInit(): Promise<void> {
     const token = this.route.snapshot.paramMap.get('token') ?? '';
     await signInWithCustomToken(this.auth, token);
+    // Wait for AngularFire's auth observable to confirm the signed-in user before
+    // navigating. Without this, the authGuard's user().pipe(take(1)) may emit null
+    // (the state before signIn propagates), causing a redirect to /login.
+    await firstValueFrom(user(this.auth).pipe(filter((u) => u !== null)));
     await this.router.navigate(['/tabs/home']);
   }
 }


### PR DESCRIPTION
## Root Cause
After `await signInWithCustomToken(auth, token)`, AngularFire's `user()` observable (which wraps `onAuthStateChanged`) may not have emitted the new user yet. The `authGuard` uses `user(auth).pipe(take(1))` — if the first emission is `null` (state before propagation), the guard redirects to `/login`. `waitForURL(/\/tabs\/home/)` then times out.

## Fix
1. **`E2eAuthComponent`**: wait for `user(auth)` to emit a non-null user before calling `router.navigate`
2. **`global-setup.ts`**: switch `waitUntil: 'networkidle'` → `'load'` (avoids stalling on keepalive connections), increase `waitForURL` timeout 30s → 60s