### PR TITLE
fix(e2e): add error handling and debug logging to global setup auth

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -47,10 +47,15 @@ async function globalSetup(config: FullConfig): Promise<void> {
   const context = await browser.newContext();
   const page = await context.newPage();
 
+  // Capture browser console and page errors so CI logs show what went wrong
+  page.on('console', (msg) => console.log(`[browser:${msg.type()}] ${msg.text()}`));
+  page.on('pageerror', (err) => console.error('[browser:pageerror]', err.message));
+
   await page.goto(`${baseURL}/e2e-auth/${customToken}`, {
     waitUntil: 'load',
     timeout: 30_000,
   });
+  console.log('[global-setup] URL after goto:', page.url());
 
   await page.waitForURL(/\/tabs\/home/, { timeout: 60_000 });
   await context.storageState({ path: AUTH_STATE_FILE });

--- a/src/app/features/e2e-auth/e2e-auth.component.ts
+++ b/src/app/features/e2e-auth/e2e-auth.component.ts
@@ -2,7 +2,7 @@ import { Component, inject, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Auth, signInWithCustomToken, user } from '@angular/fire/auth';
 import { IonContent } from '@ionic/angular/standalone';
-import { filter, firstValueFrom } from 'rxjs';
+import { filter, firstValueFrom, timeout } from 'rxjs';
 
 /**
  * E2E-only route: /e2e-auth/:token
@@ -25,11 +25,32 @@ export class E2eAuthComponent implements OnInit {
 
   async ngOnInit(): Promise<void> {
     const token = this.route.snapshot.paramMap.get('token') ?? '';
-    await signInWithCustomToken(this.auth, token);
-    // Wait for AngularFire's auth observable to confirm the signed-in user before
-    // navigating. Without this, the authGuard's user().pipe(take(1)) may emit null
-    // (the state before signIn propagates), causing a redirect to /login.
-    await firstValueFrom(user(this.auth).pipe(filter((u) => u !== null)));
+    console.log('[E2eAuth] starting sign-in, emulator:', this.auth.emulatorConfig);
+
+    try {
+      await signInWithCustomToken(this.auth, token);
+      console.log('[E2eAuth] signInWithCustomToken OK, uid:', this.auth.currentUser?.uid);
+    } catch (err) {
+      console.error('[E2eAuth] signInWithCustomToken FAILED:', err);
+      return;
+    }
+
+    try {
+      // Wait for AngularFire's auth observable to emit the signed-in user.
+      // 10s timeout prevents hanging if the auth state never propagates.
+      await firstValueFrom(
+        user(this.auth).pipe(
+          filter((u) => u !== null),
+          timeout(10_000),
+        ),
+      );
+      console.log('[E2eAuth] auth state confirmed, navigating');
+    } catch {
+      // Timeout — try navigating anyway if currentUser is set
+      console.warn('[E2eAuth] auth state timeout, currentUser:', this.auth.currentUser?.uid);
+      if (!this.auth.currentUser) return;
+    }
+
     await this.router.navigate(['/tabs/home']);
   }
 }


### PR DESCRIPTION
Adds console capture in global-setup.ts and explicit error handling + 10s timeout in E2eAuthComponent.ngOnInit to diagnose the persistent waitForURL timeout.