### PR TITLE
fix(infra): use @angular/fire/app imports to align Firebase SDK instance

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -9,8 +9,7 @@ import { provideHttpClient, withFetch } from '@angular/common/http';
 import { PreloadAllModules, Router, provideRouter, withPreloading } from '@angular/router';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 import { provideServiceWorker } from '@angular/service-worker';
-import { provideFirebaseApp } from '@angular/fire/app';
-import { getApp, getApps, initializeApp } from 'firebase/app';
+import { provideFirebaseApp, getApp, getApps, initializeApp } from '@angular/fire/app';
 import {
   ScreenTrackingService,
   getAnalytics,


### PR DESCRIPTION
## Summary

AngularFire v20 bundles its own Firebase v11 at `@angular/fire/node_modules/firebase`, while the project has Firebase v12 at the root. esbuild treats these as separate module instances with separate app registries.

Previously, `initializeApp`/`getApp`/`getApps` were imported from `firebase/app` (v12), so `initializeApp()` registered the app in the v12 registry. AngularFire's internal `getApp$1()` (v11) looked in the v11 registry and found nothing, throwing `No Firebase App '[DEFAULT]' has been created`.

## Fix

Import `initializeApp`, `getApp`, `getApps` from `@angular/fire/app` (which re-exports from AngularFire's bundled v11). The `zoneWrap` safety valve in AngularFire falls back to raw Firebase calls when invoked outside Angular injection context (module-level code at startup), so this is safe.

## Changes
- `src/app/app.config.ts`: single import from `@angular/fire/app` instead of splitting between `@angular/fire/app` and `firebase/app`

## Testing
- [x] Unit tests pass (161 tests)
- [x] This resolves the `No Firebase App '[DEFAULT]'` error in E2E CI runs

## Related Issues
Closes E2E blocker (CI run failures on `chore/promote-to-staging`)