### PR TITLE
fix(e2e): correct auth.fixture import path in spec files

### DIFF
--- a/e2e/src/navigation.spec.ts
+++ b/e2e/src/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../fixtures/auth.fixture';
+import { test, expect } from './fixtures/auth.fixture';
 
 // These tests require the Firebase Auth Emulator.
 // In CI: set USE_EMULATORS=true and start emulators before running.

--- a/e2e/src/search.spec.ts
+++ b/e2e/src/search.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '../fixtures/auth.fixture';
+import { test, expect } from './fixtures/auth.fixture';
 
 const ITUNES_SEARCH_URL = /itunes\.apple\.com\/search/;
 


### PR DESCRIPTION
## Summary

Spec files `navigation.spec.ts` and `search.spec.ts` were importing the auth fixture from `'../fixtures/auth.fixture'`, but the fixture lives at `e2e/src/fixtures/auth.fixture.ts`. This caused a `Cannot find module` error in CI that blocked E2E tests from running.

## Changes
- Fixed import path to `'./fixtures/auth.fixture'` in navigation.spec.ts and search.spec.ts

## Testing
- [ ] E2E tests now reach actual test execution instead of failing at module resolution