### PR TITLE
fix(e2e): fix OnPush rendering and test selectors

### DIFF
--- a/e2e/src/browse.spec.ts
+++ b/e2e/src/browse.spec.ts
@@ -48,7 +48,7 @@ test.describe('Browse page', () => {
   test('browse tab/category grid renders', async ({ page }) => {
     await page.goto('/tabs/browse');
 
-    await expect(page.getByRole('heading', { name: 'Browse' })).toBeVisible();
+    await expect(page.locator('ion-title').filter({ hasText: 'Browse' })).toBeVisible();
     await expect(page.locator('.category-row ion-chip')).toHaveCount(12);
     await expect(page.locator('wavely-podcast-card').first()).toBeVisible();
   });

--- a/e2e/src/login.spec.ts
+++ b/e2e/src/login.spec.ts
@@ -10,7 +10,7 @@ test.describe('Login page', () => {
 
   test('displays a Google sign-in button', async ({ page }) => {
     await page.goto('/login');
-    const googleBtn = page.getByText(/sign in with google/i);
+    const googleBtn = page.getByText(/continue with google/i);
     await expect(googleBtn).toBeVisible({ timeout: 10000 });
   });
 

--- a/e2e/src/search.spec.ts
+++ b/e2e/src/search.spec.ts
@@ -40,7 +40,7 @@ test.describe('Search page', () => {
 
     await page.goto('/tabs/search');
     const searchbar = page.locator('ion-searchbar');
-    await searchbar.fill('javascript');
+    await searchbar.locator('input').fill('javascript');
     await page.waitForSelector('wavely-podcast-card', { timeout: 5000 });
     const cards = page.locator('wavely-podcast-card');
     await expect(cards).toHaveCount(1);
@@ -57,7 +57,7 @@ test.describe('Search page', () => {
 
     await page.goto('/tabs/search');
     const searchbar = page.locator('ion-searchbar');
-    await searchbar.fill('xyznoexist');
+    await searchbar.locator('input').fill('xyznoexist');
     await page.waitForTimeout(500);
     const cards = page.locator('wavely-podcast-card');
     await expect(cards).toHaveCount(0);

--- a/src/app/features/podcast-detail/podcast-detail.page.ts
+++ b/src/app/features/podcast-detail/podcast-detail.page.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { DatePipe } from '@angular/common';
 import {
@@ -61,6 +61,7 @@ export class PodcastDetailPage {
   protected readonly playerStore = inject(PlayerStore);
   private readonly authStore = inject(AuthStore);
   private readonly syncService = inject(SubscriptionSyncService);
+  private readonly cdr = inject(ChangeDetectorRef);
 
   protected podcast: Podcast | null = null;
   protected episodes: Episode[] = [];
@@ -102,6 +103,7 @@ export class PodcastDetailPage {
         this.podcast = podcast;
         this.episodes = episodes;
         this.isLoading = false;
+        this.cdr.markForCheck();
       });
   }
 


### PR DESCRIPTION
## Summary

Four issues blocking E2E tests from passing:

### 1. `podcast-detail.page.ts` — OnPush + subscribe without markForCheck
Component uses `ChangeDetectionStrategy.OnPush` but assigns to plain class properties inside a `subscribe()` callback. Without `ChangeDetectorRef.markForCheck()`, Angular never re-renders after data loads, keeping the component stuck in the loading skeleton. This caused 9 test failures across podcast-detail, player, subscription, and home suites.

**Fix:** Inject `ChangeDetectorRef`, call `this.cdr.markForCheck()` after assignments.

### 2. `login.spec.ts` — wrong button text
Test searched for `/sign in with google/i` but actual button reads "Continue with Google".

### 3. `browse.spec.ts` — ion-title has no heading ARIA role
Test used `getByRole('heading', { name: 'Browse' })` but `ion-title` is a web component without a heading role. Changed to `locator('ion-title').filter({ hasText: 'Browse' })`.

### 4. `search.spec.ts` — ion-searchbar.fill() unsupported
Playwright cannot call `fill()` directly on an Ionic web component host. Must chain to the inner native `input`: `searchbar.locator('input').fill()`.

## Testing
- [x] Unit tests pass (161 tests)
- [ ] E2E tests expected to pass for these scenarios