### PR TITLE
fix(e2e): fix browse chip click with button attr and waitForResponse

### DIFF
--- a/e2e/src/browse.spec.ts
+++ b/e2e/src/browse.spec.ts
@@ -55,9 +55,15 @@ test.describe('Browse page', () => {
 
   test('clicking category shows relevant podcasts', async ({ page }) => {
     await page.goto('/tabs/browse');
+    // Wait for initial podcasts to load before interacting
+    await page.locator('wavely-podcast-card').first().waitFor({ timeout: 10000 });
 
-    // force: true bypasses Ionic shadow DOM pointer-events checks
-    await page.locator('ion-chip', { hasText: /^Comedy$/ }).click({ force: true });
+    // Promise.all ensures the Comedy HTTP request is actually triggered by the click.
+    // waitForResponse will fail if the click doesn't reach Angular's event handler.
+    await Promise.all([
+      page.waitForResponse(r => r.url().includes('genre/1303'), { timeout: 10000 }),
+      page.locator('ion-chip').filter({ hasText: /^Comedy$/ }).locator('ion-label').click(),
+    ]);
     await expect(page.getByText('Comedy Gold', { exact: false })).toBeVisible({ timeout: 10000 });
     await expect(page.getByText('All Category Podcast', { exact: false })).toHaveCount(0);
   });

--- a/src/app/features/browse/browse.page.html
+++ b/src/app/features/browse/browse.page.html
@@ -10,6 +10,7 @@
     <div class="category-row">
       @for (cat of categories; track cat) {
         <ion-chip
+          button
           [class.selected]="selectedCategory.id === cat.id"
           [style.--chip-color]="cat.color"
           (click)="selectCategory(cat)">


### PR DESCRIPTION
## Summary
Fix the remaining E2E test failure: clicking Comedy chip on browse page doesn't update the podcast list.

## Root Cause
`ion-chip` without the `button` attribute in Ionic 8 does not reliably propagate click events through the shadow DOM in headless browsers (CI/Playwright). The `(click)` Angular handler was never reached.

## Fix
- Add `button` attribute to `ion-chip` in browse.page.html — makes chips properly interactive in Ionic (correct semantic + shadow DOM event handling)
- Update E2E test to wait for initial podcast cards before interacting
- Use `Promise.all` + `waitForResponse` to explicitly verify the Comedy HTTP request is triggered
- Click `ion-label` (light DOM child) instead of `ion-chip` shadow host for more reliable interaction

## Changes
- `src/app/features/browse/browse.page.html` — add `button` to `ion-chip`
- `e2e/src/browse.spec.ts` — robust click + waitForResponse pattern

## Testing
- [x] Unit tests: 161 pass ✅
- [x] E2E: pushed for CI validation