### PR TITLE
fix(e2e): restore subscription spec structure after malformed edit

### DIFF
--- a/e2e/src/subscription.spec.ts
+++ b/e2e/src/subscription.spec.ts
@@ -73,7 +73,10 @@ test.describe.serial('Subscriptions', () => {
     await page.waitForURL('/tabs/library');
     // ion-title doesn't expose role="heading" — match via locator
     await expect(page.locator('ion-title').filter({ hasText: 'Library' })).toBeVisible();
-    await expect(page.locator('.podcast-card__title', { hasText: podcast.title })).toBeVisible(); async ({ page }) => {
+    await expect(page.locator('.podcast-card__title', { hasText: podcast.title })).toBeVisible();
+  });
+
+  test('unsubscribe removes podcast from library', async ({ page }) => {
     const podcast = { id: '62002', title: 'Unsubscribe Flow Podcast' };
     await mockPodcastEndpoints(page, podcast);
 


### PR DESCRIPTION
## Summary

Hotfix for syntax error introduced in PR #86's squash merge. The subscribe and unsubscribe serial test blocks were accidentally merged together, making the file unparseable.

## Changes
- Restored proper `test('unsubscribe...', async ({ page }) => {...})` wrapper around the unsubscribe test

## Testing
- [x] Unit tests pass (cached)