### PR TITLE
fix(e2e): mock audio URL in player spec; fix library selector in subscription spec

### DIFF
--- a/e2e/src/player.spec.ts
+++ b/e2e/src/player.spec.ts
@@ -60,6 +60,28 @@ test.describe('Player', () => {
       });
     });
 
+    // Serve a minimal valid WAV so the <audio> element loads without error
+    // (prevents AudioService from calling store.pause() on load failure)
+    await page.route('https://example.com/player-episode.mp3', async (route) => {
+      const wav = Buffer.from([
+        0x52, 0x49, 0x46, 0x46, 0x26, 0x00, 0x00, 0x00, // RIFF, size=38
+        0x57, 0x41, 0x56, 0x45,                         // WAVE
+        0x66, 0x6d, 0x74, 0x20, 0x10, 0x00, 0x00, 0x00, // fmt , size=16
+        0x01, 0x00, 0x01, 0x00,                         // PCM, mono
+        0x44, 0xac, 0x00, 0x00,                         // 44100 Hz
+        0x88, 0x58, 0x01, 0x00,                         // byte rate
+        0x02, 0x00, 0x10, 0x00,                         // block align, 16-bit
+        0x64, 0x61, 0x74, 0x61, 0x02, 0x00, 0x00, 0x00, // data, size=2
+        0x00, 0x00,                                     // 1 sample of silence
+      ]);
+      await route.fulfill({
+        status: 200,
+        contentType: 'audio/wav',
+        body: wav,
+        headers: { 'Accept-Ranges': 'bytes' },
+      });
+    });
+
     await page.goto(`/podcast/${PLAYER_PODCAST.id}`);
     await page.getByRole('button', { name: new RegExp(`Play ${PLAYER_EPISODE.title}`, 'i') }).click();
     await expect(page).toHaveURL(/\/episode\//);

--- a/e2e/src/subscription.spec.ts
+++ b/e2e/src/subscription.spec.ts
@@ -73,7 +73,8 @@ test.describe.serial('Subscriptions', () => {
     await page.waitForURL('/tabs/library');
     // ion-title doesn't expose role="heading" — match via locator
     await expect(page.locator('ion-title').filter({ hasText: 'Library' })).toBeVisible();
-    await expect(page.locator('.podcast-card__title', { hasText: podcast.title })).toBeVisible();
+    // Library renders subscriptions as ion-item with ion-label h2 (not wavely-podcast-card)
+    await expect(page.locator('ion-label h2').filter({ hasText: podcast.title })).toBeVisible();
   });
 
   test('unsubscribe removes podcast from library', async ({ page }) => {
@@ -86,11 +87,11 @@ test.describe.serial('Subscriptions', () => {
     await page.evaluate((u: string) => (window as any)['__e2eNavigate'](u), '/tabs/library');
     await page.waitForURL('/tabs/library');
     await expect(page.locator('ion-title').filter({ hasText: 'Library' })).toBeVisible();
-    await expect(page.locator('.podcast-card__title', { hasText: podcast.title })).toBeVisible();
+    await expect(page.locator('ion-label h2').filter({ hasText: podcast.title })).toBeVisible();
 
     await page
       .getByRole('button', { name: new RegExp(`Unsubscribe from ${podcast.title}`, 'i') })
       .click();
-    await expect(page.locator('.podcast-card__title', { hasText: podcast.title })).toHaveCount(0);
+    await expect(page.locator('ion-label h2').filter({ hasText: podcast.title })).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary
Fix the 2 remaining E2E failures blocking PR #69 (dev → staging).

## Changes
- **player.spec.ts**: mock audio URL with minimal WAV so AudioService doesn't pause on load error
- **subscription.spec.ts**: use `ion-label h2` selector (library uses ion-item lists, not wavely-podcast-card)

## Related Issues
Closes E2E failures blocking #69