### PR TITLE
fix(e2e): assert ion-icon[name] instead of aria-label; simplify audio mock

### DIFF
--- a/e2e/src/player.spec.ts
+++ b/e2e/src/player.spec.ts
@@ -47,26 +47,19 @@ test.skip(() => !process.env['USE_EMULATORS'], 'Requires Firebase emulators');
 
 test.describe('Player', () => {
   test.beforeEach(async ({ page }) => {
-    // Prevent the <audio> element from making real network requests or firing error
-    // events (which would cause AudioService to call store.pause() in CI).
-    // We suppress src (no fetch), override play() (resolves immediately), and
-    // no-op load() — keeping PlayerStore.isPlaying in sync with test clicks.
+    // Prevent AudioService from calling store.pause() in CI where real audio
+    // URLs can't load. Two guard layers:
+    // 1. play() always resolves — the .catch() path in AudioService never fires.
+    // 2. Suppress 'error' addEventListener on media elements — the browser's
+    //    audio-load-failure error event has no handler to call store.pause().
     await page.addInitScript(() => {
       HTMLMediaElement.prototype.play = function () {
         return Promise.resolve();
       };
-      const srcDesc = Object.getOwnPropertyDescriptor(HTMLMediaElement.prototype, 'src');
-      Object.defineProperty(HTMLMediaElement.prototype, 'src', {
-        get() {
-          return srcDesc?.get?.call(this) ?? '';
-        },
-        set(_v) {
-          /* suppress src to prevent network fetch and error events */
-        },
-        configurable: true,
-      });
-      HTMLMediaElement.prototype.load = function () {
-        /* suppress */
+      const origAddEventListener = HTMLMediaElement.prototype.addEventListener;
+      HTMLMediaElement.prototype.addEventListener = function (type, listener, options) {
+        if (type === 'error') return; // block AudioService's error → store.pause() path
+        origAddEventListener.call(this, type, listener, options);
       };
     });
 
@@ -99,14 +92,18 @@ test.describe('Player', () => {
   });
 
   test('play/pause toggle', async ({ page }) => {
+    // Ionic 8 forwards aria-label from the ion-button host to its shadow <button>
+    // and clears it on the host, so toHaveAttribute('aria-label') on ion-button is
+    // unreliable. Assert on ion-icon[name] instead — it directly reflects isPlaying.
+    const icon = page.locator('wavely-mini-player ion-button.mini-player__play-btn ion-icon');
     const toggleButton = page.locator('wavely-mini-player').locator('ion-button.mini-player__play-btn');
 
-    await expect(toggleButton).toHaveAttribute('aria-label', /pause/i);
+    await expect(icon).toHaveAttribute('name', 'pause-circle');
     await toggleButton.click();
-    await expect(toggleButton).toHaveAttribute('aria-label', /play/i);
+    await expect(icon).toHaveAttribute('name', 'play-circle');
 
     await toggleButton.click();
-    await expect(toggleButton).toHaveAttribute('aria-label', /pause/i);
+    await expect(icon).toHaveAttribute('name', 'pause-circle');
   });
 
   test('clicking mini player opens full player', async ({ page }) => {


### PR DESCRIPTION
## Summary

Fixes the final remaining E2E failure blocking PR #69 (player play/pause toggle).

## Root cause

Ionic 8's `ion-button` component forwards `aria-label` from the host element to its inner shadow `<button>`, then **clears** the host attribute (to avoid ARIA duplication across shadow DOM boundary). This means `toHaveAttribute('aria-label', /pause/i)` on `<ion-button>` always returns `""` after Ionic hydrates — unrelated to the play state.

## Changes

### `e2e/player.spec.ts`
- **Assertion**: Replace `toHaveAttribute('aria-label')` on `ion-button` with `toHaveAttribute('name')` on the `ion-icon` inside it. `ion-icon` uses Stencil's `@Prop({ reflect: true }) name`, so `name` is always a reliable DOM attribute directly bound to `isPlaying` via `[name]="isPlaying() ? 'pause-circle' : 'play-circle'"`.
- **`addInitScript`**: Remove the `src` setter override (this caused aria-label to appear null during the Ionic hydration window). Replace with suppressing `addEventListener('error', ...)` on `HTMLMediaElement` — cleanly blocks the `AudioService` error → `store.pause()` path without touching the src/load lifecycle.

## Testing
- [x] Unit tests unchanged (no app logic changes)
- [x] E2E fix verified by root-cause analysis of CI trace

## Related Issues
Part of #69 (dev → staging promotion for v0.6.0)