### PR TITLE
fix(e2e): wait for Subscribed state; use slot=end selector for unsubscribe

### DIFF
--- a/e2e/src/subscription.spec.ts
+++ b/e2e/src/subscription.spec.ts
@@ -83,19 +83,23 @@ test.describe.serial('Subscriptions', () => {
 
     await page.goto(`/podcast/${podcast.id}`);
     await page.getByRole('button', { name: /^subscribe$/i }).click();
+    // Wait for the optimistic update to reflect in the UI before navigating
+    // (button changes to 'Subscribed' as soon as the store adds the podcast)
+    await expect(page.getByRole('button', { name: /^subscribed$/i })).toBeVisible({ timeout: 5000 });
 
     await page.evaluate((u: string) => (window as any)['__e2eNavigate'](u), '/tabs/library');
     await page.waitForURL('/tabs/library');
     await expect(page.locator('ion-title').filter({ hasText: 'Library' })).toBeVisible();
     // Library renders subscriptions as ion-item with ion-label h2 (not wavely-podcast-card)
-    await expect(page.locator('ion-label h2').filter({ hasText: podcast.title })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('ion-label h2').filter({ hasText: podcast.title })).toBeVisible({ timeout: 15000 });
 
-    // Use ion-button[aria-label] selector to avoid strict mode violation:
-    // getByRole matches both the ion-item's native button AND the ion-button ✕ button
-    // because the ion-item's accessible name includes the aria-label of child buttons.
-    await page
-      .locator(`ion-button[aria-label="Unsubscribe from ${podcast.title}"]`)
-      .click();
+    // ion-button[aria-label] is unreliable after Ionic hydration: Ionic forwards
+    // the host aria-label to the shadow <button> and clears the host attribute.
+    // Use ion-button[slot="end"] scoped to the podcast's ion-item-sliding instead.
+    const podcastItem = page.locator('ion-item-sliding').filter({
+      has: page.locator('ion-label h2').filter({ hasText: podcast.title }),
+    });
+    await podcastItem.locator('ion-button[slot="end"]').click();
     await expect(page.locator('ion-label h2').filter({ hasText: podcast.title })).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary

Fixes remaining unsubscribe E2E test failure.

## Root Causes

### 1. `ion-button[aria-label]` cleared by Ionic after hydration (retries 0 & 2)
Ionic 8's `ion-button` forwards `aria-label` from the host element to its shadow `<button>`, then **clears the host attribute** to avoid duplicate ARIA reads across shadow boundary. Playwright's CSS selector `ion-button[aria-label="..."]" targets the host — which has no attribute after hydration, so the locator never resolves.

**Fix:** Use `ion-item-sliding` scoped `ion-button[slot="end"]` instead. The `slot` attribute is a light DOM projection hint — it is NOT forwarded to shadow DOM, so it reliably identifies the unsubscribe button.

### 2. Race condition: subscription not visible in library (retry 1)
After clicking Subscribe, the test immediately navigated away. If `loadFromFirestore()` resolved between the click and the navigation, it could overwrite the optimistic update before the merge logic had a chance to run.

**Fix:** After clicking Subscribe, explicitly wait for the button to read `'Subscribed'` — this confirms the `PodcastsStore` optimistic update is applied and the store has the podcast. Navigation only proceeds once the UI confirms the state.

## Changes
- `e2e/subscription.spec.ts`: `ion-button[slot="end"]` selector + wait for `/^subscribed$/i` + increased library timeout to 15 s

## Related Issues
Part of #69 (dev → staging promotion for v0.6.0)