### PR TITLE
fix(ci): use Node 22 for semantic-release

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -13,6 +13,10 @@ jobs:
         with:
           fetch-depth: 0  # semantic-release needs full history
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.10'


### PR DESCRIPTION
## Summary
`semantic-release` now requires Node `^22.14.0 || >=24.10.0` — the runner default (Node 20.20.1 via `setup-bun`) no longer satisfies it.

## Fix
Add `actions/setup-node@v4` with `node-version: '22'` before `setup-bun`. Bun still handles all package management; Node 22 is only needed for `bunx semantic-release`.

## Error seen in production run
```
[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.20.1.
```