### PR TITLE
chore(release): promote staging to main [v0.6.0]

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -13,6 +13,10 @@ jobs:
         with:
           fetch-depth: 0  # semantic-release needs full history
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.10'


### PR DESCRIPTION
## Summary
Final v0.6.0 release — all fixes validated through staging.

## Changes
- fix(e2e): player audio mock + `ion-icon[name]` assertion
- fix(e2e): unsubscribe selector + navigation context race
- fix(infra): Firebase DI single instance
- fix(library): subscription sync merge strategy
- fix(ci): Node 22 for semantic-release
- docs: README overhaul with live env links

## CI
- ✅ 28/28 E2E — run #23089481809
- ✅ Unit tests passing