### PR TITLE
fix(ci): grant contents:write permission for semantic-release

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # semantic-release: push tags + create GitHub releases
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
GITHUB_TOKEN needs `contents: write` to push version tags and create GitHub releases. Default token permissions are read-only for contents in restricted repos.