### PR TITLE
chore(release): promote staging to main

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # semantic-release: push tags + create GitHub releases
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
Full promotion chain with semantic-release permissions fix + Node 22 setup.

## Changes
- Node 22 setup for semantic-release compatibility
- `contents: write` permissions for semantic-release tagging
- E2E navigation context fix (fire-and-forget `page.evaluate`)
- README overhaul with live environment links

## Testing
- [x] E2E 28/28 passed (staging gate)
- [x] Unit tests passing