### PR TITLE
fix(infra): remove @semantic-release/git plugin (protected branch conflict)

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,15 +6,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
     ["@semantic-release/npm", { "npmPublish": false }],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
Remove `@semantic-release/git` plugin from `.releaserc.json`.

## Problem
The plugin tried to push `CHANGELOG.md` + `package.json` directly to `main` after tagging, but branch protection requires PRs and 3 status checks — causing `GH006: Protected branch update failed` every deploy.

## Fix
Remove the git plugin. `@semantic-release/github` still creates the GitHub Release + version tags. CHANGELOG won't be auto-committed but that's acceptable.

## Testing
- [ ] Unit tests passing
- [x] No E2E needed (CI config only)