### PR TITLE
chore(release): promote staging to main [semantic-release fix]

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,15 +6,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
     ["@semantic-release/npm", { "npmPublish": false }],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
Removes `@semantic-release/git` plugin so semantic-release no longer tries to push directly to protected `main`.

## Changes
- `.releaserc.json`: removed `@semantic-release/changelog` + `@semantic-release/git` plugins
- GitHub Release + version tags still created via `@semantic-release/github`

## Testing
- [x] E2E 28/28 passed