### PR TITLE
fix(auth): post-signin redirect + responsive desktop layout

### DIFF
--- a/src/app/features/login/login.page.ts
+++ b/src/app/features/login/login.page.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, effect, inject } from '@angular/core';
 import { IonButton, IonContent, IonIcon, IonSpinner } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { logoGoogle } from 'ionicons/icons';
@@ -94,12 +94,17 @@ export class LoginPage {
 
   constructor() {
     addIcons({ logoGoogle });
+    // Navigate reactively when auth state resolves — signInWithPopup updates
+    // user$ asynchronously, so checking isAuthenticated() right after await
+    // always returns false. The effect fires when the signal actually changes.
+    effect(() => {
+      if (this.authStore.isAuthenticated()) {
+        this.router.navigate(['/tabs/home']);
+      }
+    });
   }
 
   async signIn(): Promise<void> {
     await this.authStore.signInWithGoogle();
-    if (this.authStore.isAuthenticated()) {
-      this.router.navigate(['/tabs/home']);
-    }
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -119,3 +119,74 @@ ion-toolbar {
 .full-player-modal {
   --border-radius: 20px 20px 0 0;
 }
+
+/* ─── Desktop / wide-screen responsive ─── */
+
+// Constrain app frame on very large monitors (≥1440px)
+@media (min-width: 1440px) {
+  ion-app {
+    max-width: 1440px;
+    margin: 0 auto;
+    box-shadow: 0 0 60px rgba(0, 0, 0, 0.08);
+  }
+}
+
+// Tablet and desktop: responsive podcast grids + generous padding
+@media (min-width: 768px) {
+  // Grow from fixed 2-col to auto-fill responsive grid
+  .podcast-grid {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)) !important;
+    gap: 20px !important;
+  }
+
+  // Section padding breathes more on wide screens
+  .home-section {
+    padding-left: 32px !important;
+    padding-right: 32px !important;
+  }
+
+  // Toolbar content gets side padding so it's not flush to the edge
+  ion-toolbar {
+    --padding-start: 16px;
+    --padding-end: 16px;
+  }
+
+  // Browse category chips wrap instead of scrolling off-screen
+  .category-row {
+    flex-wrap: wrap !important;
+    width: auto !important;
+  }
+
+  // Search bar gets a sensible max-width on desktop
+  .search-bar-wrapper {
+    max-width: 640px;
+    margin: 16px auto;
+  }
+}
+
+@media (min-width: 1024px) {
+  .podcast-grid {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)) !important;
+    gap: 24px !important;
+  }
+
+  .home-section {
+    padding-left: 48px !important;
+    padding-right: 48px !important;
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .category-scroll {
+    padding-left: 48px !important;
+    padding-right: 48px !important;
+  }
+
+  // Browse podcast grid gets max-width container
+  ion-content .podcast-grid {
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+}


### PR DESCRIPTION
## Summary
Two fixes in one branch.

### Auth redirect (closes part of #33)
After `signInWithPopup` the auth store updates `user` asynchronously via the `user$` observable. The login page was checking `isAuthenticated()` synchronously right after `await signInWithGoogle()` — always `false` at that point, so navigation never fired. Fixed with an Angular `effect()` that watches the signal reactively.

### Desktop responsive layout
- **768px+**: podcast grids auto-fill (`minmax(160px, 1fr)`), category chips wrap, search bar max-width 640px
- **1024px+**: grids use `minmax(180px)`, sections and content max-width 1200px centered  
- **1440px+**: `ion-app` capped at 1440px with subtle shadow

## Testing
- [x] 163/163 unit tests passing
- [x] Build passes (no new errors)