### PR TITLE
fix(e2e): server routes + E2E test fixes for Discovery milestone

### DIFF
--- a/e2e/src/browse.spec.ts
+++ b/e2e/src/browse.spec.ts
@@ -53,19 +53,20 @@ test.describe('Browse page', () => {
     await expect(page.locator('wavely-podcast-card').first()).toBeVisible();
   });
 
-  test('clicking category shows relevant podcasts', async ({ page }) => {
+  test('clicking category navigates to category detail page', async ({ page }) => {
     await page.goto('/tabs/browse');
     // Wait for initial podcasts to load before interacting
     await page.locator('wavely-podcast-card').first().waitFor({ timeout: 10000 });
 
-    // Promise.all ensures the Comedy HTTP request is actually triggered by the click.
-    // waitForResponse will fail if the click doesn't reach Angular's event handler.
+    // Clicking a non-"All" category chip now navigates to /browse/category/:genreId
     await Promise.all([
-      page.waitForResponse(r => r.url().includes('genre/1303'), { timeout: 10000 }),
+      page.waitForURL(/\/browse\/category\/1303/, { timeout: 10000 }),
       page.locator('ion-chip').filter({ hasText: /^Comedy$/ }).locator('ion-label').click(),
     ]);
+    await expect(page.url()).toContain('/browse/category/1303');
+    // Category detail page should load and show results for genre 1303
+    await expect(page.locator('wavely-podcast-card').first()).toBeVisible({ timeout: 10000 });
     await expect(page.getByText('Comedy Gold', { exact: false })).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText('All Category Podcast', { exact: false })).toHaveCount(0);
   });
 
   test('trending/new sections visible', async ({ page }) => {

--- a/e2e/src/home.spec.ts
+++ b/e2e/src/home.spec.ts
@@ -130,10 +130,11 @@ test.describe('Home page', () => {
     await page.getByRole('button', { name: /^subscribe$/i }).click();
 
     // Navigate within the SPA to preserve PodcastsStore state (page.goto would reload,
-    // potentially losing the subscription before the Firestore write completes)
-    await page.evaluate((u: string) => (window as any)['__e2eNavigate'](u), '/tabs/home');
-    await page.waitForURL('/tabs/home');
-    await expect(page.getByRole('heading', { name: 'My Podcasts' })).toBeVisible();
-    await expect(page.locator('.podcast-card__title', { hasText: SUBSCRIPTION_PODCAST.title })).toBeVisible();
+    // potentially losing the subscription before the Firestore write completes).
+    // Use void + .catch() to handle context destruction that can occur during navigation.
+    void page.evaluate((u: string) => (window as any)['__e2eNavigate'](u), '/tabs/home').catch(() => {});
+    await page.waitForURL('/tabs/home', { timeout: 10000 });
+    await expect(page.getByRole('heading', { name: 'My Podcasts' })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.podcast-card__title', { hasText: SUBSCRIPTION_PODCAST.title })).toBeVisible({ timeout: 10000 });
   });
 });

--- a/src/app/app.routes.server.e2e.ts
+++ b/src/app/app.routes.server.e2e.ts
@@ -16,6 +16,10 @@ export const serverRoutes: ServerRoute[] = [
     renderMode: RenderMode.Client,
   },
   {
+    path: 'browse/category/:genreId',
+    renderMode: RenderMode.Client,
+  },
+  {
     path: 'podcast/:id',
     renderMode: RenderMode.Server,
   },


### PR DESCRIPTION
Backports fixes from staging promotion:
- Add `browse/category/:genreId` `RenderMode.Client` to `app.routes.server.e2e.ts` (E2E build was failing without this)
- Update browse E2E test: category click now navigates to `/browse/category/:genreId` (behaviour changed in #40)
- Fix home E2E test: use `void+catch` for `__e2eNavigate` to avoid Playwright execution context destruction