### PR TITLE
chore: promote staging to main (Discovery & Library v1.1.0)

### DIFF
--- a/SDD.md
+++ b/SDD.md
@@ -1,0 +1,884 @@
+# Wavely — Software Design Document
+
+> **Version:** 1.1.0 | **Last updated:** March 2026  
+> **Status:** Living document — update with every milestone
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Tech Stack](#2-tech-stack)
+3. [Architecture Overview](#3-architecture-overview)
+4. [Route Structure](#4-route-structure)
+5. [State Management](#5-state-management)
+6. [Service Layer](#6-service-layer)
+7. [Data Models](#7-data-models)
+8. [Feature Pages](#8-feature-pages)
+9. [Shared Components](#9-shared-components)
+10. [Authentication Flow](#10-authentication-flow)
+11. [Firebase Integration](#11-firebase-integration)
+12. [External API Integration](#12-external-api-integration)
+13. [Audio Playback Architecture](#13-audio-playback-architecture)
+14. [Angular Patterns](#14-angular-patterns)
+15. [Environment Configuration](#15-environment-configuration)
+16. [Testing Strategy](#16-testing-strategy)
+17. [CI/CD Pipeline](#17-cicd-pipeline)
+18. [Deployment](#18-deployment)
+19. [Next Milestone — Discovery & Library](#19-next-milestone--discovery--library)
+20. [Known Limitations & Tech Debt](#20-known-limitations--tech-debt)
+
+---
+
+## 1. Executive Summary
+
+**Wavely** is a Google Podcasts-inspired cross-platform podcast application targeting **Android, iOS, and Web**. It is built as a true multi-platform product using Angular + Ionic + Capacitor, with Firebase for authentication and cloud persistence.
+
+| Attribute | Value |
+|-----------|-------|
+| Current version | `v1.1.0` |
+| Production URL | https://wavely-f659c.web.app |
+| Landing page | https://bndF1.github.io/wavely |
+| Repository | https://github.com/bndF1/wavely |
+| Platforms | Web PWA · Android (Capacitor) · iOS (Capacitor) |
+
+**MVP Features (v1.1.0):**
+- Google OAuth login
+- Podcast discovery via iTunes Search API (country-aware)
+- Full-screen and mini audio player with progress persistence
+- Media Session API (lockscreen / notification controls)
+- Up Next queue with auto-advance
+- Listening history (Firestore-synced)
+- Subscriptions (Firestore-synced)
+- Offline resilience with error states
+- PWA (service worker, installable)
+- Lighthouse CI gate (performance + accessibility)
+
+---
+
+## 2. Tech Stack
+
+| Layer | Choice | Version |
+|-------|--------|---------|
+| Workspace | Nx | 22.x |
+| Framework | Angular standalone | 21.2.x |
+| Mobile UI | Ionic Framework | 8.8.1 |
+| Native bridge | Capacitor | 8.2.0 |
+| State management | NgRx SignalStore | 21.0.1 |
+| Auth & DB | Firebase SDK + AngularFire | 12.10.0 / 20.0.1 |
+| Podcast data | iTunes Search API | — |
+| Testing (unit) | Jest | built-in |
+| Testing (E2E) | Playwright | built-in |
+| CI/CD | GitHub Actions | — |
+| Hosting | Firebase Hosting | — |
+| Landing page | GitHub Pages | — |
+| Error tracking | Sentry | — |
+
+---
+
+## 3. Architecture Overview
+
+```
+src/app/
+├── app.config.ts              ← Bootstrap providers (Firebase, Router, Ionic, SW, Sentry)
+├── app.routes.ts              ← Route tree (lazy-loaded)
+├── app.routes.server.ts       ← SSR render modes
+│
+├── core/
+│   ├── auth/
+│   │   └── auth.service.ts    ← Firebase Auth wrapper (Google OAuth)
+│   ├── guards/
+│   │   └── auth.guard.ts      ← Route protection
+│   ├── models/
+│   │   └── podcast.model.ts   ← Domain interfaces (Podcast, Episode, etc.)
+│   └── services/
+│       ├── audio.service.ts            ← HTMLAudioElement owner, Media Session
+│       ├── history-sync.service.ts     ← Firestore history persistence
+│       ├── network.service.ts          ← Online/offline signal
+│       ├── podcast-api.service.ts      ← iTunes API + country detection
+│       ├── progress-sync.service.ts    ← Throttled playback position → Firestore
+│       ├── subscription-sync.service.ts ← Firestore subscription persistence
+│       └── theme.service.ts            ← System/light/dark theme
+│
+├── features/
+│   ├── browse/                ← Category browsing + trending
+│   ├── e2e-auth/              ← Test-only custom token login
+│   ├── episode-detail/        ← Episode playback UI
+│   ├── home/                  ← Trending + featured
+│   ├── library/               ← Subscriptions, history, profile
+│   ├── login/                 ← Google OAuth entry
+│   ├── player/
+│   │   ├── full-player/       ← Fullscreen player modal
+│   │   └── mini-player/       ← Persistent bottom bar
+│   ├── podcast-detail/        ← Podcast info + episode list
+│   ├── search/                ← iTunes search + country detection
+│   └── tabs/                  ← Tab shell + mini-player host
+│
+├── shared/
+│   └── components/
+│       ├── empty-state/        ← "No results" UI
+│       ├── error-state/        ← Error + retry UI
+│       ├── offline-banner/     ← Dismissible offline warning
+│       └── podcast-card/       ← Podcast display card
+│
+└── store/
+    ├── auth/
+    │   └── auth.store.ts       ← User session signal store
+    ├── history/
+    │   └── history.store.ts    ← Listening history signal store
+    ├── player/
+    │   └── player.store.ts     ← Playback state signal store
+    └── podcasts/
+        └── podcasts.store.ts   ← Search results + subscriptions signal store
+```
+
+### Data Flow Layers
+
+```
+UI Components
+    ↕ signals / methods
+Signal Stores (PlayerStore, PodcastsStore, AuthStore, HistoryStore)
+    ↕ observables / async
+Services (AudioService, PodcastApiService, Sync services)
+    ↕
+External (Firebase Firestore · iTunes API · Web Audio API · Media Session API)
+```
+
+---
+
+## 4. Route Structure
+
+```
+/
+├── ''                         → redirect /tabs (pathMatch: full)
+├── login                      → LoginPage (Google OAuth)
+├── e2e-auth/:token            → E2eAuthComponent (emulator only, tree-shaken in prod)
+│
+└── tabs (authGuard)           → TabsComponent + MiniPlayerComponent
+    ├── ''                     → redirect home
+    ├── home                   → HomePage
+    ├── browse                 → BrowsePage
+    ├── search                 → SearchPage
+    └── library                → LibraryPage
+
+/podcast/:id                   → PodcastDetailPage (lazy)
+/episode/:id                   → EpisodeDetailPage (lazy)
+```
+
+**Route features:**
+- All feature components are lazy-loaded via `loadComponent()`
+- `PreloadAllModules` strategy — routes preload after initial render
+- `authGuard` on `/tabs` — redirects unauthenticated users to `/login`
+- No wildcard route (404s propagate to Firebase Hosting fallback)
+
+---
+
+## 5. State Management
+
+All state lives in **NgRx SignalStore** (`@ngrx/signals`). No NgModules, no RxJS Subjects for state — only signals and `patchState`.
+
+### 5.1 PlayerStore
+
+**File:** `src/app/store/player/player.store.ts`
+
+```typescript
+interface PlayerState {
+  currentEpisode: Episode | null;
+  isPlaying:      boolean;
+  currentTime:    number;       // seconds
+  duration:       number;       // seconds
+  playbackRate:   number;       // 1 | 1.5 | 2
+  queue:          Episode[];    // Up Next list
+  isMinimised:    boolean;      // mini-player visibility
+}
+```
+
+| Method | What it does |
+|--------|-------------|
+| `play(episode)` | Set episode, playing=true, time=0 |
+| `pause()` / `resume()` | Toggle isPlaying |
+| `seek(time)` | User-initiated time jump |
+| `updateProgress(t, d)` | Internal audio event sync (not a seek) |
+| `skipBack(15)` / `skipForward(30)` | Timed skips |
+| `setPlaybackRate(rate)` | Speed change |
+| `addToQueue(ep)` / `removeFromQueue(id)` / `clearQueue()` | Queue CRUD |
+| `playNext()` | Advance queue, play first item |
+| `toggleMinimise()` | Show/hide mini-player |
+| `close()` | Clear episode, reset all state |
+
+### 5.2 AuthStore
+
+**File:** `src/app/store/auth/auth.store.ts`
+
+```typescript
+interface AuthState {
+  user:    User | null;   // Firebase Auth User
+  loading: boolean;
+  error:   string | null;
+}
+// Computed: isAuthenticated, displayName, photoURL, email
+```
+
+**Side effects on auth change:**
+- Sign in → load subscriptions + history from Firestore
+- Sign out → clear in-memory subscriptions + history
+- User switch (A→B) → clear A's data, load B's (race-guarded)
+
+### 5.3 PodcastsStore
+
+**File:** `src/app/store/podcasts/podcasts.store.ts`
+
+```typescript
+interface PodcastsState {
+  searchResults: Podcast[];
+  subscriptions: Podcast[];
+  trending:      Podcast[];
+  isLoading:     boolean;
+  error:         string | null;
+  searchQuery:   string;
+}
+```
+
+### 5.4 HistoryStore
+
+**File:** `src/app/store/history/history.store.ts`
+
+```typescript
+interface HistoryState {
+  entries:   HistoryEntry[];   // auto-sorted by lastPlayedAt DESC
+  isLoading: boolean;
+}
+```
+
+`addOrUpdate(entry)` upserts and re-sorts automatically.
+
+---
+
+## 6. Service Layer
+
+### 6.1 PodcastApiService
+
+**Responsibilities:** iTunes Search API wrapper, country detection, model mapping.
+
+| Method | Returns | Notes |
+|--------|---------|-------|
+| `detectCountry()` | `string` | Browser locale → ISO 3166-1 α-2 |
+| `searchPodcasts(term, country?)` | `Observable<Podcast[]>` | Max 50 results |
+| `lookupPodcast(itunesId)` | `Observable<Podcast>` | Single podcast details |
+| `getTrendingPodcasts(limit, genreId?)` | `Observable<Podcast[]>` | iTunes RSS top chart |
+| `getPodcastEpisodes(itunesId, limit)` | `Observable<Episode[]>` | Most recent episodes |
+
+- Base URL: `https://itunes.apple.com`
+- SSR-safe: no browser APIs on server
+- No API key required (public iTunes API)
+
+### 6.2 AudioService
+
+**Responsibilities:** Owns the single `HTMLAudioElement`. Reacts to PlayerStore signals. Drives Media Session API.
+
+**Reactive chain:**
+```
+PlayerStore.currentEpisode() signal changes
+  → load audio.src
+  → restore saved progress from ProgressSyncService (async)
+  → play()
+
+PlayerStore.isPlaying() signal changes
+  → audio.play() | audio.pause()
+
+audio timeupdate event
+  → PlayerStore.updateProgress()
+  → ProgressSyncService.scheduleWrite() (throttled 5s)
+
+audio ended event
+  → PlayerStore.playNext() (auto-advance queue)
+  → HistorySyncService.recordPlay() (mark completed)
+```
+
+**Media Session handlers:** play, pause, stop, seekforward (30s), seekbackward (15s), seekto, previoustrack, nexttrack.
+
+### 6.3 ProgressSyncService
+
+**Path:** `users/{uid}/progress/{episodeId}`
+
+| Method | Notes |
+|--------|-------|
+| `loadProgress(episodeId, uid)` | Returns saved position (0 if none or completed) |
+| `scheduleWrite(episodeId, pos, dur, uid)` | Throttled — max 1 write per 5s |
+| `flush()` | Immediate write (on pause/episode change) |
+| `markCompleted(episodeId, dur, uid)` | Sets `completedAt` timestamp |
+
+### 6.4 HistorySyncService
+
+**Path:** `users/{uid}/history/{episodeId}`
+
+| Method | Notes |
+|--------|-------|
+| `recordPlay(entry, uid)` | Upsert (merge) history entry |
+| `loadHistory(uid)` | Returns entries sorted by lastPlayedAt DESC |
+| `clearHistory(uid)` | Deletes all history docs for user |
+
+### 6.5 SubscriptionSyncService
+
+**Path:** `users/{uid}/subscriptions/{podcastId}`
+
+| Method | Notes |
+|--------|-------|
+| `loadFromFirestore(uid, isStillCurrentUser)` | Stale-result guard prevents cross-user contamination |
+| `addSubscription(podcast, uid)` | Optimistic update → Firestore write → rollback on error |
+| `removeSubscription(podcastId, uid)` | Same optimistic pattern |
+| `clearSubscriptions()` | In-memory clear only (on sign-out) |
+
+### 6.6 ThemeService
+
+Signal: `mode: signal<'system' | 'light' | 'dark'>`. Applies `ion-palette-dark` class to `<html>`. Persists to localStorage.
+
+### 6.7 NetworkService
+
+Signal: `isOnline: signal<boolean>`. Listens to `window` online/offline events. SSR-safe.
+
+---
+
+## 7. Data Models
+
+**File:** `src/app/core/models/podcast.model.ts`
+
+```typescript
+interface Podcast {
+  id:                string;   // iTunes collectionId
+  title:             string;
+  author:            string;
+  description:       string;
+  artworkUrl:        string;   // 600×600 preferred
+  feedUrl:           string;   // RSS feed URL
+  genres:            string[];
+  episodeCount?:     number;
+  latestReleaseDate?: string;  // ISO date
+}
+
+interface Episode {
+  id:            string;       // iTunes trackId
+  podcastId:     string;       // iTunes collectionId
+  title:         string;
+  description:   string;
+  audioUrl:      string;       // playback URL
+  imageUrl?:     string;
+  podcastTitle?: string;       // added dynamically by components
+  duration:      number;       // seconds
+  releaseDate:   string;       // ISO date
+  fileSize?:     number;       // bytes
+}
+
+interface PlaybackProgress {
+  episodeId:   string;
+  position:    number;    // seconds
+  duration:    number;
+  completed:   boolean;
+  updatedAt:   Date;
+}
+
+interface HistoryEntry {
+  episodeId:    string;
+  episodeTitle: string;
+  podcastTitle: string;
+  imageUrl:     string;
+  position:     number;
+  duration:     number;
+  lastPlayedAt: number;   // unix timestamp ms
+  completed:    boolean;
+}
+
+interface Subscription {
+  podcastId:    string;
+  subscribedAt: Date;
+  lastSeen?:    string;   // last episode ID seen
+}
+```
+
+---
+
+## 8. Feature Pages
+
+All components: `standalone: true`, `inject()` DI, `ChangeDetectionStrategy.OnPush`.
+
+| Route | Component | Key Dependencies | Responsibility |
+|-------|-----------|-----------------|----------------|
+| `/login` | LoginPage | AuthStore | Google OAuth entry, redirects on auth |
+| `/tabs` | TabsComponent | PlayerStore | Tab shell, hosts MiniPlayerComponent |
+| `/tabs/home` | HomePage | PodcastsStore, PodcastApiService | Trending feed, pull-to-refresh |
+| `/tabs/browse` | BrowsePage | PodcastApiService | Category filter chips + trending per genre |
+| `/tabs/search` | SearchPage | PodcastApiService, PodcastsStore | Debounced search, country toggle, global mode |
+| `/tabs/library` | LibraryPage | AuthStore, PodcastsStore, HistoryStore | Subscriptions, history, theme, sign out |
+| `/podcast/:id` | PodcastDetailPage | PodcastApiService, PodcastsStore, PlayerStore | Podcast info, episode list, subscribe/unsubscribe |
+| `/episode/:id` | EpisodeDetailPage | PlayerStore | Episode info, play controls, add-to-queue |
+| *(modal)* | FullPlayerComponent | PlayerStore | Full-screen player modal |
+| *(in tabs)* | MiniPlayerComponent | PlayerStore | Compact player bar |
+| `/e2e-auth/:token` | E2eAuthComponent | AuthService | Test-only: custom token sign-in |
+
+---
+
+## 9. Shared Components
+
+| Component | Inputs | Outputs | Purpose |
+|-----------|--------|---------|---------|
+| `PodcastCardComponent` | `podcast` (required), `loading` | `cardClick` | Podcast tile (art + title + author) |
+| `OfflineBannerComponent` | — | — | Dismissible offline warning |
+| `EmptyStateComponent` | `message`, `icon`, `actionLabel?` | `action` | "No results" / empty list |
+| `ErrorStateComponent` | `message`, `retryLabel?` | `retry` | Error message with retry button |
+
+---
+
+## 10. Authentication Flow
+
+### Sign-In
+
+```
+1. User lands on /login (unauthenticated or redirected by authGuard)
+2. User taps "Continue with Google"
+3. LoginPage → authStore.signInWithGoogle()
+4. AuthStore → authService.signInWithGoogle()
+5. Firebase Auth → signInWithPopup(GoogleAuthProvider)
+6. Firebase Auth state changes → user$ emits user
+7. AuthStore.init() listener fires:
+   - patchState({ user, loading: false })
+   - subscriptionSync.loadFromFirestore(uid, guard)
+   - historySyncService.loadHistory(uid) → historyStore.setEntries()
+8. LoginPage effect detects isAuthenticated() → router.navigate(['/tabs/home'])
+```
+
+### Route Protection
+
+```typescript
+// authGuard: CanActivateFn
+return user(auth).pipe(
+  take(1),
+  map(u => u ? true : router.createUrlTree(['/login']))
+);
+```
+
+Applied to `/tabs` — protects all child routes (home, browse, search, library).
+
+### Sign-Out
+
+```
+1. LibraryPage → authStore.signOut()
+2. AuthStore → authService.signOut() (Firebase sign out)
+3. user$ emits null
+4. AuthStore clears user, subscriptions, history
+5. Redirect to /login
+```
+
+### E2E Auth
+
+For Playwright tests (`environment.useEmulators = true`):
+
+```
+1. global-setup.ts creates Firebase Admin custom token
+2. Playwright navigates to /e2e-auth/{token}
+3. E2eAuthComponent calls signInWithCustomToken(auth, token)
+4. Auth state stored via storageState (Playwright context)
+```
+
+---
+
+## 11. Firebase Integration
+
+### Firestore Schema
+
+```
+users/{uid}/
+├── subscriptions/{podcastId}      Podcast object (full)
+│     ├── id, title, author, description
+│     ├── artworkUrl, feedUrl, genres
+│     └── subscribedAt
+│
+├── progress/{episodeId}           Playback position
+│     ├── episodeId: string
+│     ├── position:  number (seconds)
+│     ├── duration:  number
+│     ├── updatedAt: number (unix ms)
+│     └── completedAt: number | null
+│
+└── history/{episodeId}            Listening history entry
+      ├── episodeId:    string
+      ├── episodeTitle: string
+      ├── podcastTitle: string
+      ├── imageUrl:     string
+      ├── position:     number
+      ├── duration:     number
+      ├── lastPlayedAt: number (unix ms)
+      └── completed:    boolean
+```
+
+### Security Rules
+
+Firestore rules (`firestore.rules`) enforce:
+- Read/write only for the authenticated owner (`request.auth.uid == userId`)
+- No cross-user access
+
+### Firebase Services Used
+
+| Service | Usage |
+|---------|-------|
+| Firebase Auth | Google OAuth, session persistence |
+| Firestore | subscriptions, playback progress, history |
+| Firebase Hosting | Production + staging + preview channels |
+| Firebase Analytics | Screen tracking (production only) |
+
+### Emulators (E2E)
+
+- **Auth emulator:** `localhost:9099`
+- **Firestore emulator:** `localhost:8080`
+- Activated via `environment.useEmulators = true`
+
+---
+
+## 12. External API Integration
+
+### iTunes Search API
+
+**Base URL:** `https://itunes.apple.com`  
+**Authentication:** None required (public)
+
+| Endpoint | Usage |
+|----------|-------|
+| `/search?term={q}&country={cc}&media=podcast&limit=50` | Podcast search |
+| `/lookup?id={itunesId}&media=podcast&entity=podcastEpisode&limit=50` | Podcast + episodes |
+| `https://rss.applemarketingtools.com/api/v2/{cc}/podcasts/top/{n}/podcasts.json` | Trending podcasts |
+
+**Country Detection:**
+
+```typescript
+detectCountry(): string {
+  const lang = navigator.language || 'en';
+  const map = { 'en': 'us', 'es': 'es', 'fr': 'fr', 'de': 'de', ... };
+  return map[lang.split('-')[0]] ?? 'us';
+}
+```
+
+**Model Mapping:** iTunes raw objects → `Podcast` / `Episode` domain models inside service (consumers never see raw iTunes types).
+
+---
+
+## 13. Audio Playback Architecture
+
+### HTMLAudioElement Lifecycle
+
+```
+PodcastDetailPage.playEpisode(episode)
+  ↓ playerStore.play(episode)
+  ↓ AudioService.effect() fires (currentEpisode() changed)
+  ↓ audio.src = episode.audioUrl
+  ↓ progressSync.loadProgress(episodeId, uid)  [async]
+  ↓ audio.play()
+  ↓ loadedmetadata → apply pending restore position
+  ↓ timeupdate → playerStore.updateProgress() + scheduleWrite()
+  ↓ ended → playerStore.playNext() + historySyncService.recordPlay()
+```
+
+### Progress Persistence
+
+- **Write throttle:** max 1 write per 5 seconds during playback
+- **Flush triggers:** pause, episode change, app unload
+- **Minimum position:** ≥ 2 seconds (ignores accidental starts)
+- **Completion:** sets `completedAt` timestamp; position NOT restored on re-open
+- **Merge writes:** `{ merge: true }` — safe for concurrent device access
+
+### Media Session API
+
+```typescript
+navigator.mediaSession.metadata = new MediaMetadata({
+  title, artist, artwork: [{ src: imageUrl }]
+});
+// Handlers: play, pause, stop, seekforward, seekbackward, seekto,
+//           previoustrack, nexttrack
+```
+
+---
+
+## 14. Angular Patterns
+
+### Dependency Injection — always `inject()`
+
+```typescript
+// ✅ Correct
+export class HomePage {
+  private readonly api = inject(PodcastApiService);
+  protected readonly store = inject(PodcastsStore);
+}
+// ❌ Never constructor injection
+```
+
+### Signals — all state reads
+
+```typescript
+const count = signal(0);
+count();          // read
+count.set(1);     // write
+count.update(n => n + 1);  // update
+computed(() => count() * 2);  // derived
+effect(() => { console.log(count()); });  // side effect
+```
+
+### NgRx SignalStore
+
+```typescript
+export const PodcastsStore = signalStore(
+  { providedIn: 'root' },
+  withState<PodcastsState>(initialState),
+  withComputed((store) => ({
+    hasResults: computed(() => store.searchResults().length > 0),
+  })),
+  withMethods((store) => ({
+    setResults(results: Podcast[]): void {
+      patchState(store, { searchResults: results });
+    },
+  })),
+);
+```
+
+### Component Anatomy
+
+```typescript
+@Component({
+  selector: 'wavely-example',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, IonButton, RouterLink, ...],
+  templateUrl: './example.component.html',
+})
+export class ExampleComponent {
+  protected readonly store = inject(SomeStore);
+  readonly someOutput = output<string>();
+  @Input({ required: true }) someInput!: string;
+}
+```
+
+### RxJS — search debounce pattern
+
+```typescript
+this.searchSubject.pipe(
+  debounceTime(300),
+  distinctUntilChanged(),
+  switchMap(term => this.api.searchPodcasts(term, this.country)),
+  takeUntilDestroyed(),
+).subscribe(results => this.store.setSearchResults(results, term));
+```
+
+### SSR Safety
+
+```typescript
+constructor() {
+  if (isPlatformBrowser(inject(PLATFORM_ID))) {
+    // browser-only code (window, document, audio)
+  }
+}
+```
+
+---
+
+## 15. Environment Configuration
+
+| File | Used when |
+|------|-----------|
+| `environment.ts` | Local dev |
+| `environment.prod.ts` | Production build |
+| `environment.staging.ts` | Staging build |
+| `environment.e2e.ts` | Playwright E2E |
+
+```typescript
+interface Environment {
+  production:    boolean;
+  appVersion:    string;          // e.g., "1.1.0"
+  useEmulators:  boolean;
+  sentryDsn:     string;          // empty → Sentry no-op
+  firebase:      FirebaseOptions; // from NG_APP_FIREBASE_* env vars
+}
+```
+
+**Environment injection:** `scripts/generate-env.mjs` reads process env vars and writes `environment.prod.ts` at build time. Nx `fileReplacements` selects the correct file per build configuration.
+
+---
+
+## 16. Testing Strategy
+
+### Unit Tests
+
+- **Runner:** Jest (via Nx)
+- **Files:** `*.spec.ts` alongside source files
+- **Coverage target:** 80%
+- **Run:** `bun run test`
+- **Current state:** 213 tests passing, 26 suites ✅
+
+Key tested units:
+- All stores (PlayerStore, AuthStore, PodcastsStore, HistoryStore)
+- All services (AudioService, PodcastApiService, ProgressSyncService, etc.)
+- Auth guard
+- All feature pages (shallow render)
+- All shared components
+
+### E2E Tests
+
+- **Runner:** Playwright (Chromium)
+- **Location:** `e2e/src/`
+- **Auth:** Custom Firebase token → `/e2e-auth/:token` (emulator)
+- **Requires:** Firebase emulators running (`firebase emulators:start`)
+- **Run:** `bun nx run wavely:e2e`
+
+Key E2E flows:
+- Login / logout
+- Podcast search
+- Subscribe / unsubscribe
+- Play episode, progress persistence
+- Library contents after history
+- Offline banner behavior
+
+### CI Gates
+
+| PR target | Required checks |
+|-----------|-----------------|
+| `dev` | Unit tests |
+| `staging` | Unit tests + E2E |
+| `main` | Unit tests + E2E + Lighthouse CI |
+
+---
+
+## 17. CI/CD Pipeline
+
+### Branch Strategy
+
+```
+feature/* (individual work)
+    ↓ PR
+dev (integration, staging preview deploy)
+    ↓ PR
+staging (full E2E gate, staging.web.app)
+    ↓ PR
+main (Lighthouse gate, production deploy, semantic-release)
+```
+
+**Rules:**
+- Never commit directly to `main` or `staging`
+- Feature branches from `dev`
+- Hotfixes from `main`, backport to `dev`
+- Conventional Commits: `feat(scope): desc`, `fix(scope): desc`, `chore(scope): desc`
+
+### GitHub Actions Workflows
+
+| Workflow | Trigger | Jobs |
+|----------|---------|------|
+| `firebase-hosting-preview.yml` | PR opened/updated | Build + deploy preview channel |
+| `firebase-hosting-staging.yml` | Push to `dev` | Unit tests + deploy staging |
+| `e2e.yml` | PR → `staging` or `main` | Firebase emulators + Playwright |
+| `firebase-hosting.yml` | Push to `main` | Build + unit tests + deploy prod + semantic-release |
+| `pages.yml` | Push to `main` (docs/**) | Deploy GitHub Pages landing |
+
+### Squash-Merge Divergence
+
+When promoting dev → staging (squash merge), staging accumulates unique squash commits.  
+Next promotion must use the **reconcile approach**:
+
+```bash
+git checkout -b sync/promote-X origin/staging
+git checkout origin/dev -- .
+git commit -m "chore: reconcile staging with dev"
+# Open PR to staging → CLEAN (no conflict)
+```
+
+---
+
+## 18. Deployment
+
+### Production
+
+- **URL:** https://wavely-f659c.web.app  
+- **Trigger:** Merge to `main`  
+- **Artifacts:** Angular SSR build → `dist/wavely/browser/` + Express server  
+- **Post-deploy:** `cp dist/wavely/browser/index.csr.html dist/wavely/browser/index.html` (SSR build quirk)
+
+### Staging
+
+- **URL:** https://wavely-f659c--staging.web.app  
+- **Trigger:** Push to `dev`
+
+### Preview Channels
+
+- **Trigger:** Any PR  
+- **URL format:** `https://wavely-f659c--pr-{N}-{hash}.web.app`  
+- **Expiry:** 7 days
+
+### Capacitor (Native)
+
+```bash
+bun run cap:build   # nx build + copy index + cap copy + cap sync
+```
+
+---
+
+## 19. Next Milestone — Discovery & Library
+
+**Milestone label:** v1.1.0 Discovery & Library  
+**GitHub issues:** [#38](https://github.com/bndF1/wavely/issues/38), [#39](https://github.com/bndF1/wavely/issues/39), [#40](https://github.com/bndF1/wavely/issues/40)
+
+### Issue #38 — Search: Recent Searches & Quick Suggestions
+
+**Goal:** Store recent search queries and display them as suggestions before the user types.
+
+**Acceptance criteria:**
+- Show last 8 search queries when search input is focused and empty
+- Persist in `localStorage` (no account needed)
+- Clear individual items or all history
+- Tapping a suggestion fills the search input
+
+**Design notes:**
+- New `SearchHistoryService` (localStorage, no Firestore)
+- `SearchPage` updated: show suggestion list when `query === ''` and input focused
+- Suggestion list → existing `EmptyStateComponent` pattern or new dedicated UI
+
+### Issue #39 — Library: Episode Filtering
+
+**Goal:** Filter episodes in Library by status so users find unplayed/in-progress content faster.
+
+**Acceptance criteria:**
+- Filter chips: All | Unplayed | In Progress | Completed
+- "Mark as played / unplayed" action per episode item
+- Bulk "Mark all as played" option
+- Filtering respects `HistoryEntry.completed` + `position` from HistoryStore
+
+**Design notes:**
+- HistoryStore needs a `filter: FilterChip` signal + filtered computed
+- `markPlayed(episodeId)` / `markUnplayed(episodeId)` methods on HistoryStore + HistorySyncService
+- Library page filter chips above episode list
+
+### Issue #40 — Browse: Featured Section + Category Detail Pages
+
+**Goal:** Improve Browse with featured podcasts, editors picks, and category drilldown.
+
+**Acceptance criteria:**
+- Featured banner carousel (top of Browse)
+- Category detail page: tapping a category → list of top podcasts for that genre
+- "New & Noteworthy" section
+- Paginated category results
+
+**Design notes:**
+- New route: `/browse/category/:genreId` → CategoryDetailPage
+- `PodcastApiService.getTrendingPodcasts(50, genreId)` already supports `genreId` param
+- Featured/Noteworthy: curate from top iTunes results per locale
+- BrowsePage becomes a hub (chips link to category detail)
+
+---
+
+## 20. Known Limitations & Tech Debt
+
+| Item | Severity | Notes |
+|------|----------|-------|
+| No wildcard 404 route | Low | Firebase Hosting handles 404 fallback via `firebase.json` rewrites |
+| iTunes API only | Medium | No Podcast Index fallback; Apple can rate-limit or change structure |
+| Episode descriptions are HTML strings | Low | No sanitization pipe — rendered as text, XSS risk if rendered as HTML |
+| `podcastTitle` added dynamically to `Episode` | Low | Type-unsafe workaround; should be included in `Episode` model |
+| SSR Express serves all routes | Low | `server.ts` uses wildcard express route; needs review for performance |
+| Capacitor sync not automated in CI | Medium | Capacitor sync must be run manually before native builds |
+| No offline episode downloads | Planned | v2.0.0 milestone |
+| No push notifications | Planned | v1.2.0 milestone |
+| No sleep timer | Planned | v2.0.0 milestone |
+| Progress restoration race condition | Low | `AudioService.pendingRestorePosition` handles it; a signal-based approach would be cleaner |

--- a/e2e/src/browse.spec.ts
+++ b/e2e/src/browse.spec.ts
@@ -53,19 +53,20 @@ test.describe('Browse page', () => {
     await expect(page.locator('wavely-podcast-card').first()).toBeVisible();
   });
 
-  test('clicking category shows relevant podcasts', async ({ page }) => {
+  test('clicking category navigates to category detail page', async ({ page }) => {
     await page.goto('/tabs/browse');
     // Wait for initial podcasts to load before interacting
     await page.locator('wavely-podcast-card').first().waitFor({ timeout: 10000 });
 
-    // Promise.all ensures the Comedy HTTP request is actually triggered by the click.
-    // waitForResponse will fail if the click doesn't reach Angular's event handler.
+    // Clicking a non-"All" category chip now navigates to /browse/category/:genreId
     await Promise.all([
-      page.waitForResponse(r => r.url().includes('genre/1303'), { timeout: 10000 }),
+      page.waitForURL(/\/browse\/category\/1303/, { timeout: 10000 }),
       page.locator('ion-chip').filter({ hasText: /^Comedy$/ }).locator('ion-label').click(),
     ]);
+    await expect(page.url()).toContain('/browse/category/1303');
+    // Category detail page should load and show results for genre 1303
+    await expect(page.locator('wavely-podcast-card').first()).toBeVisible({ timeout: 10000 });
     await expect(page.getByText('Comedy Gold', { exact: false })).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText('All Category Podcast', { exact: false })).toHaveCount(0);
   });
 
   test('trending/new sections visible', async ({ page }) => {

--- a/e2e/src/home.spec.ts
+++ b/e2e/src/home.spec.ts
@@ -130,10 +130,11 @@ test.describe('Home page', () => {
     await page.getByRole('button', { name: /^subscribe$/i }).click();
 
     // Navigate within the SPA to preserve PodcastsStore state (page.goto would reload,
-    // potentially losing the subscription before the Firestore write completes)
-    await page.evaluate((u: string) => (window as any)['__e2eNavigate'](u), '/tabs/home');
-    await page.waitForURL('/tabs/home');
-    await expect(page.getByRole('heading', { name: 'My Podcasts' })).toBeVisible();
-    await expect(page.locator('.podcast-card__title', { hasText: SUBSCRIPTION_PODCAST.title })).toBeVisible();
+    // potentially losing the subscription before the Firestore write completes).
+    // Use void + .catch() to handle context destruction that can occur during navigation.
+    void page.evaluate((u: string) => (window as any)['__e2eNavigate'](u), '/tabs/home').catch(() => {});
+    await page.waitForURL('/tabs/home', { timeout: 10000 });
+    await expect(page.getByRole('heading', { name: 'My Podcasts' })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('.podcast-card__title', { hasText: SUBSCRIPTION_PODCAST.title })).toBeVisible({ timeout: 10000 });
   });
 });

--- a/src/app/app.routes.server.e2e.ts
+++ b/src/app/app.routes.server.e2e.ts
@@ -16,6 +16,10 @@ export const serverRoutes: ServerRoute[] = [
     renderMode: RenderMode.Client,
   },
   {
+    path: 'browse/category/:genreId',
+    renderMode: RenderMode.Client,
+  },
+  {
     path: 'podcast/:id',
     renderMode: RenderMode.Server,
   },

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -10,6 +10,10 @@ export const serverRoutes: ServerRoute[] = [
     renderMode: RenderMode.Client,
   },
   {
+    path: 'browse/category/:genreId',
+    renderMode: RenderMode.Client,
+  },
+  {
     path: 'podcast/:id',
     renderMode: RenderMode.Server,
   },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -60,6 +60,13 @@ export const appRoutes: Route[] = [
     ],
   },
   {
+    path: 'browse/category/:genreId',
+    loadComponent: () =>
+      import('./features/browse/category-detail/category-detail.page').then(
+        (m) => m.CategoryDetailPage
+      ),
+  },
+  {
     path: 'podcast/:id',
     loadComponent: () =>
       import('./features/podcast-detail/podcast-detail.page').then(

--- a/src/app/core/services/history-sync.service.ts
+++ b/src/app/core/services/history-sync.service.ts
@@ -1,5 +1,13 @@
 import { inject, Injectable } from '@angular/core';
-import { Firestore, collection, deleteDoc, doc, getDocs, setDoc } from '@angular/fire/firestore';
+import {
+  Firestore,
+  collection,
+  deleteDoc,
+  doc,
+  getDocs,
+  setDoc,
+  updateDoc,
+} from '@angular/fire/firestore';
 import { HistoryEntry, HistoryStore } from '../../store/history/history.store';
 
 @Injectable({ providedIn: 'root' })
@@ -9,12 +17,7 @@ export class HistorySyncService {
 
   async recordPlay(entry: HistoryEntry, uid: string): Promise<void> {
     if (!uid || !entry.episodeId) return;
-
-    const normalized: HistoryEntry = {
-      ...entry,
-      lastPlayedAt: entry.lastPlayedAt || Date.now(),
-    };
-
+    const normalized: HistoryEntry = { ...entry, lastPlayedAt: entry.lastPlayedAt || Date.now() };
     try {
       const docRef = doc(this.firestore, 'users', uid, 'history', normalized.episodeId);
       await setDoc(docRef, normalized, { merge: true });
@@ -24,9 +27,28 @@ export class HistorySyncService {
     }
   }
 
+  async updateEntry(episodeId: string, partial: Partial<HistoryEntry>, uid: string): Promise<void> {
+    if (!uid || !episodeId) return;
+
+    const docRef = doc(this.firestore, 'users', uid, 'history', episodeId);
+    try {
+      await updateDoc(docRef, partial);
+    } catch (updateError) {
+      try {
+        await setDoc(docRef, partial, { merge: true });
+      } catch (setError) {
+        console.error('[HistorySyncService] Failed to update entry', { episodeId, partial, updateError, setError });
+        return;
+      }
+    }
+
+    const existingEntry = this.historyStore.entries().find((entry) => entry.episodeId === episodeId);
+    if (!existingEntry) return;
+    this.historyStore.addOrUpdate({ ...existingEntry, ...partial, episodeId });
+  }
+
   async loadHistory(uid: string): Promise<HistoryEntry[]> {
     if (!uid) return [];
-
     try {
       const colRef = collection(this.firestore, 'users', uid, 'history');
       const snapshot = await getDocs(colRef);
@@ -54,11 +76,7 @@ export class HistorySyncService {
   }
 
   async clearHistory(uid: string): Promise<void> {
-    if (!uid) {
-      this.historyStore.clear();
-      return;
-    }
-
+    if (!uid) { this.historyStore.clear(); return; }
     try {
       const colRef = collection(this.firestore, 'users', uid, 'history');
       const snapshot = await getDocs(colRef);

--- a/src/app/core/services/search-history.service.spec.ts
+++ b/src/app/core/services/search-history.service.spec.ts
@@ -1,0 +1,65 @@
+import { TestBed } from '@angular/core/testing';
+import { SearchHistoryService } from './search-history.service';
+
+describe('SearchHistoryService', () => {
+  let service: SearchHistoryService;
+  const STORAGE_KEY = 'wavely_search_history';
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({ providers: [SearchHistoryService] });
+    service = TestBed.inject(SearchHistoryService);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    TestBed.resetTestingModule();
+  });
+
+  it('returns empty array when nothing is stored', () => {
+    expect(service.getHistory()).toEqual([]);
+  });
+
+  it('addQuery adds and deduplicates entries', () => {
+    service.addQuery('Angular');
+    service.addQuery('Ionic');
+    service.addQuery('angular');
+
+    expect(service.getHistory()).toEqual(['angular', 'Ionic']);
+  });
+
+  it('addQuery limits history to 8 items', () => {
+    for (let i = 1; i <= 10; i += 1) {
+      service.addQuery(`Query ${i}`);
+    }
+
+    expect(service.getHistory()).toEqual([
+      'Query 10',
+      'Query 9',
+      'Query 8',
+      'Query 7',
+      'Query 6',
+      'Query 5',
+      'Query 4',
+      'Query 3',
+    ]);
+  });
+
+  it('removeQuery removes a single entry', () => {
+    service.addQuery('Angular');
+    service.addQuery('Ionic');
+
+    service.removeQuery('Angular');
+
+    expect(service.getHistory()).toEqual(['Ionic']);
+  });
+
+  it('clearAll empties storage', () => {
+    service.addQuery('Angular');
+
+    service.clearAll();
+
+    expect(service.getHistory()).toEqual([]);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});

--- a/src/app/core/services/search-history.service.ts
+++ b/src/app/core/services/search-history.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class SearchHistoryService {
+  private readonly STORAGE_KEY = 'wavely_search_history';
+  private readonly MAX_ITEMS = 8;
+
+  getHistory(): string[] {
+    const rawHistory = localStorage.getItem(this.STORAGE_KEY);
+    if (!rawHistory) {
+      return [];
+    }
+
+    try {
+      const parsedHistory = JSON.parse(rawHistory);
+      if (!Array.isArray(parsedHistory)) {
+        return [];
+      }
+
+      return parsedHistory.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+    } catch {
+      return [];
+    }
+  }
+
+  addQuery(term: string): void {
+    const normalizedTerm = term.trim();
+    if (!normalizedTerm) {
+      return;
+    }
+
+    const history = this.getHistory();
+    const dedupedHistory = history.filter((item) => item.toLowerCase() !== normalizedTerm.toLowerCase());
+    const nextHistory = [normalizedTerm, ...dedupedHistory].slice(0, this.MAX_ITEMS);
+
+    localStorage.setItem(this.STORAGE_KEY, JSON.stringify(nextHistory));
+  }
+
+  removeQuery(term: string): void {
+    const normalizedTerm = term.trim();
+    if (!normalizedTerm) {
+      return;
+    }
+
+    const nextHistory = this.getHistory().filter((item) => item.toLowerCase() !== normalizedTerm.toLowerCase());
+    localStorage.setItem(this.STORAGE_KEY, JSON.stringify(nextHistory));
+  }
+
+  clearAll(): void {
+    localStorage.removeItem(this.STORAGE_KEY);
+  }
+}

--- a/src/app/features/browse/browse.page.html
+++ b/src/app/features/browse/browse.page.html
@@ -5,6 +5,34 @@
 </ion-header>
 
 <ion-content>
+  <section class="browse-section">
+    <h2 class="section-title">Featured</h2>
+
+    @if (isLoading()) {
+      <div class="podcast-carousel" aria-label="Loading featured podcasts">
+        @for (s of skeletons; track s) {
+          <ion-card class="skeleton-card" aria-hidden="true">
+            <ion-skeleton-text [animated]="true" style="height: 120px"></ion-skeleton-text>
+            <ion-card-content>
+              <ion-skeleton-text [animated]="true" style="width: 85%; height: 16px"></ion-skeleton-text>
+              <ion-skeleton-text [animated]="true" style="width: 60%; height: 14px"></ion-skeleton-text>
+            </ion-card-content>
+          </ion-card>
+        }
+      </div>
+    } @else if (featuredPodcasts().length > 0) {
+      <div class="podcast-carousel">
+        @for (podcast of featuredPodcasts(); track podcast.id) {
+          <div class="carousel-item">
+            <wavely-podcast-card [podcast]="podcast" (cardClick)="navigateToPodcast($event)"></wavely-podcast-card>
+          </div>
+        }
+      </div>
+    } @else {
+      <ion-text color="medium" class="section-empty">No featured podcasts right now.</ion-text>
+    }
+  </section>
+
   <div class="category-scroll">
     <div class="category-row">
       @if (isLoading()) {
@@ -14,7 +42,7 @@
           </ion-chip>
         }
       } @else {
-        @for (cat of categories; track cat) {
+        @for (cat of categories; track cat.id) {
           <ion-chip
             button
             [class.selected]="selectedCategory().id === cat.id"
@@ -27,45 +55,77 @@
     </div>
   </div>
 
-  @if (isLoading()) {
-    <div class="podcast-grid" aria-label="Loading category podcasts">
-      @for (s of skeletons; track s) {
-        <ion-card class="skeleton-card" aria-hidden="true">
-          <ion-skeleton-text [animated]="true" style="height: 120px"></ion-skeleton-text>
-          <ion-card-content>
-            <ion-skeleton-text [animated]="true" style="width: 85%; height: 16px"></ion-skeleton-text>
-            <ion-skeleton-text [animated]="true" style="width: 60%; height: 14px"></ion-skeleton-text>
-          </ion-card-content>
-        </ion-card>
-      }
-    </div>
-  }
+  <section class="browse-section">
+    <h2 class="section-title">New &amp; Noteworthy</h2>
 
-  @if (!isLoading() && !error() && topPodcasts().length > 0) {
-    <div class="podcast-grid">
-      @for (podcast of topPodcasts(); track podcast) {
-        <wavely-podcast-card [podcast]="podcast" (cardClick)="navigateToPodcast($event)"></wavely-podcast-card>
-      }
-    </div>
-  }
+    @if (isLoading()) {
+      <div class="podcast-carousel" aria-label="Loading new and noteworthy podcasts">
+        @for (s of skeletons; track s) {
+          <ion-card class="skeleton-card" aria-hidden="true">
+            <ion-skeleton-text [animated]="true" style="height: 120px"></ion-skeleton-text>
+            <ion-card-content>
+              <ion-skeleton-text [animated]="true" style="width: 85%; height: 16px"></ion-skeleton-text>
+              <ion-skeleton-text [animated]="true" style="width: 60%; height: 14px"></ion-skeleton-text>
+            </ion-card-content>
+          </ion-card>
+        }
+      </div>
+    } @else if (newNoteworthyPodcasts().length > 0) {
+      <div class="podcast-carousel">
+        @for (podcast of newNoteworthyPodcasts(); track podcast.id) {
+          <div class="carousel-item">
+            <wavely-podcast-card [podcast]="podcast" (cardClick)="navigateToPodcast($event)"></wavely-podcast-card>
+          </div>
+        }
+      </div>
+    } @else {
+      <ion-text color="medium" class="section-empty">No new and noteworthy podcasts yet.</ion-text>
+    }
+  </section>
 
-  @if (error() && !isLoading()) {
-    <wavely-empty-state
-      icon="alert-circle-outline"
-      title="Could not load this category"
-      [subtitle]="error()!"
-      actionLabel="Retry"
-      (action)="retryCurrentCategory()">
-    </wavely-empty-state>
-  }
+  <section class="browse-section">
+    <h2 class="section-title">Top Podcasts</h2>
 
-  @if (!isLoading() && !error() && topPodcasts().length === 0) {
-    <wavely-empty-state
-      icon="search-outline"
-      title="No podcasts in this category"
-      subtitle="Try another category or check back later."
-      actionLabel="Refresh"
-      (action)="retryCurrentCategory()">
-    </wavely-empty-state>
-  }
+    @if (isLoading()) {
+      <div class="podcast-grid" aria-label="Loading category podcasts">
+        @for (s of skeletons; track s) {
+          <ion-card class="skeleton-card" aria-hidden="true">
+            <ion-skeleton-text [animated]="true" style="height: 120px"></ion-skeleton-text>
+            <ion-card-content>
+              <ion-skeleton-text [animated]="true" style="width: 85%; height: 16px"></ion-skeleton-text>
+              <ion-skeleton-text [animated]="true" style="width: 60%; height: 14px"></ion-skeleton-text>
+            </ion-card-content>
+          </ion-card>
+        }
+      </div>
+    }
+
+    @if (!isLoading() && !error() && topPodcasts().length > 0) {
+      <div class="podcast-grid">
+        @for (podcast of topPodcasts(); track podcast.id) {
+          <wavely-podcast-card [podcast]="podcast" (cardClick)="navigateToPodcast($event)"></wavely-podcast-card>
+        }
+      </div>
+    }
+
+    @if (error() && !isLoading()) {
+      <wavely-empty-state
+        icon="alert-circle-outline"
+        title="Could not load browse"
+        [subtitle]="error()!"
+        actionLabel="Retry"
+        (action)="retryCurrentCategory()">
+      </wavely-empty-state>
+    }
+
+    @if (!isLoading() && !error() && topPodcasts().length === 0) {
+      <wavely-empty-state
+        icon="search-outline"
+        title="No podcasts available"
+        subtitle="Try refreshing or check back later."
+        actionLabel="Refresh"
+        (action)="retryCurrentCategory()">
+      </wavely-empty-state>
+    }
+  </section>
 </ion-content>

--- a/src/app/features/browse/browse.page.scss
+++ b/src/app/features/browse/browse.page.scss
@@ -1,6 +1,6 @@
 .category-scroll {
   overflow-x: auto;
-  padding: 12px 16px 4px;
+  padding: 4px 16px 8px;
   position: sticky;
   top: 0;
   z-index: 10;
@@ -34,9 +34,43 @@ ion-chip {
   pointer-events: none;
 }
 
+.browse-section {
+  padding: 12px 16px 8px;
+}
+
+.section-title {
+  margin: 0 0 12px;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--wavely-on-surface);
+}
+
+.section-empty {
+  display: block;
+  font-size: 14px;
+  line-height: 1.5;
+  padding: 8px 2px;
+}
+
 .podcast-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
-  padding: 16px;
+}
+
+.podcast-carousel {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.carousel-item,
+.skeleton-card {
+  flex: 0 0 min(220px, 64vw);
 }

--- a/src/app/features/browse/browse.page.spec.ts
+++ b/src/app/features/browse/browse.page.spec.ts
@@ -12,7 +12,9 @@ describe('BrowsePage', () => {
   let component: BrowsePage;
 
   const mockApi = {
-    getTrendingPodcasts: jest.fn().mockReturnValue(of([mockPodcast({ id: 'pod-1' })])),
+    getTrendingPodcasts: jest.fn((limit: number) =>
+      of([mockPodcast({ id: `pod-${limit}` })])
+    ),
   };
   const mockRouter = { navigate: jest.fn() };
 
@@ -38,16 +40,40 @@ describe('BrowsePage', () => {
     TestBed.resetTestingModule();
   });
 
-  it('creates and loads initial category', () => {
+  it('creates and loads all browse sections for the default category', () => {
     expect(component).toBeTruthy();
     expect(mockApi.getTrendingPodcasts).toHaveBeenCalledWith(25);
+    expect(mockApi.getTrendingPodcasts).toHaveBeenCalledWith(5);
+    expect(mockApi.getTrendingPodcasts).toHaveBeenCalledWith(10);
   });
 
-  it('changes category and navigates to podcast detail', () => {
+  it('navigates to category detail for non-all category chips', () => {
+    const allCallsBeforeSelect = mockApi.getTrendingPodcasts.mock.calls.length;
+
     (component as any).selectCategory(PODCAST_CATEGORIES[1]);
+
+    expect(mockRouter.navigate).toHaveBeenCalledWith([
+      '/browse/category',
+      PODCAST_CATEGORIES[1].id,
+    ]);
+    expect(mockApi.getTrendingPodcasts.mock.calls.length).toBe(allCallsBeforeSelect);
+  });
+
+  it('reloads in-page sections when switching back to all category', () => {
+    const allCategory = PODCAST_CATEGORIES[0];
+    const categoryDetail = PODCAST_CATEGORIES[1];
+
+    (component as any).selectCategory(categoryDetail);
+    (component as any).selectCategory(allCategory);
+
+    expect(mockApi.getTrendingPodcasts).toHaveBeenCalledWith(25);
+    expect(mockApi.getTrendingPodcasts).toHaveBeenCalledWith(5);
+    expect(mockApi.getTrendingPodcasts).toHaveBeenCalledWith(10);
+  });
+
+  it('navigates to podcast detail', () => {
     (component as any).navigateToPodcast(mockPodcast({ id: 'pod-9' }));
 
-    expect(mockApi.getTrendingPodcasts).toHaveBeenCalledWith(25, PODCAST_CATEGORIES[1].id);
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/podcast', 'pod-9']);
   });
 });

--- a/src/app/features/browse/browse.page.ts
+++ b/src/app/features/browse/browse.page.ts
@@ -1,4 +1,10 @@
-import { Component, OnDestroy, inject, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnDestroy,
+  inject,
+  signal,
+} from '@angular/core';
 import { Router } from '@angular/router';
 
 import {
@@ -11,10 +17,11 @@ import {
   IonSkeletonText,
   IonCard,
   IonCardContent,
+  IonText,
 } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { alertCircleOutline, refreshOutline, searchOutline } from 'ionicons/icons';
-import { Subject, switchMap, catchError, of, takeUntil, tap } from 'rxjs';
+import { Subject, switchMap, catchError, of, takeUntil, tap, forkJoin } from 'rxjs';
 import { PodcastCardComponent } from '../../shared/components/podcast-card/podcast-card.component';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
 import { Podcast } from '../../core/models/podcast.model';
@@ -48,6 +55,8 @@ const CHIP_SKELETON_COUNT = 6;
   selector: 'wavely-browse',
   templateUrl: './browse.page.html',
   styleUrls: ['./browse.page.scss'],
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     IonHeader,
     IonToolbar,
@@ -58,6 +67,7 @@ const CHIP_SKELETON_COUNT = 6;
     IonSkeletonText,
     IonCard,
     IonCardContent,
+    IonText,
     PodcastCardComponent,
     EmptyStateComponent,
   ],
@@ -69,18 +79,11 @@ export class BrowsePage implements OnDestroy {
   protected readonly categories = PODCAST_CATEGORIES;
   protected readonly skeletons = Array.from({ length: SKELETON_COUNT });
   protected readonly chipSkeletons = Array.from({ length: CHIP_SKELETON_COUNT });
-  protected readonly skeletonPodcast: Podcast = {
-    id: '',
-    title: '',
-    author: '',
-    description: '',
-    artworkUrl: '',
-    feedUrl: '',
-    genres: [],
-  };
 
   protected selectedCategory = signal(PODCAST_CATEGORIES[0]);
   protected topPodcasts = signal<Podcast[]>([]);
+  protected featuredPodcasts = signal<Podcast[]>([]);
+  protected newNoteworthyPodcasts = signal<Podcast[]>([]);
   protected isLoading = signal(false);
   protected error = signal<string | null>(null);
 
@@ -96,20 +99,39 @@ export class BrowsePage implements OnDestroy {
           this.isLoading.set(true);
           this.error.set(null);
           this.topPodcasts.set([]);
+          this.featuredPodcasts.set([]);
+          this.newNoteworthyPodcasts.set([]);
         }),
         switchMap((cat) => {
-          const obs$ = cat.id === 0 ? this.api.getTrendingPodcasts(25) : this.api.getTrendingPodcasts(25, cat.id);
-          return obs$.pipe(
+          if (cat.id !== 0) {
+            return of({
+              topPodcasts: [] as Podcast[],
+              featuredPodcasts: [] as Podcast[],
+              newNoteworthyPodcasts: [] as Podcast[],
+            });
+          }
+
+          return forkJoin({
+            topPodcasts: this.api.getTrendingPodcasts(25),
+            featuredPodcasts: this.api.getTrendingPodcasts(5),
+            newNoteworthyPodcasts: this.api.getTrendingPodcasts(10),
+          }).pipe(
             catchError(() => {
               this.error.set('Could not load podcasts. Please try again.');
-              return of([] as Podcast[]);
+              return of({
+                topPodcasts: [] as Podcast[],
+                featuredPodcasts: [] as Podcast[],
+                newNoteworthyPodcasts: [] as Podcast[],
+              });
             })
           );
         }),
         takeUntil(this.destroy$)
       )
-      .subscribe((podcasts) => {
-        this.topPodcasts.set(podcasts);
+      .subscribe((response) => {
+        this.topPodcasts.set(response.topPodcasts);
+        this.featuredPodcasts.set(response.featuredPodcasts);
+        this.newNoteworthyPodcasts.set(response.newNoteworthyPodcasts);
         this.isLoading.set(false);
       });
 
@@ -123,11 +145,23 @@ export class BrowsePage implements OnDestroy {
 
   protected selectCategory(category: PodcastCategory): void {
     if (this.selectedCategory().id === category.id) return;
+
     this.selectedCategory.set(category);
-    this.category$.next(category);
+
+    if (category.id === 0) {
+      this.category$.next(category);
+      return;
+    }
+
+    this.router.navigate(['/browse/category', category.id]);
   }
 
   protected retryCurrentCategory(): void {
+    if (this.selectedCategory().id !== 0) {
+      this.router.navigate(['/browse/category', this.selectedCategory().id]);
+      return;
+    }
+
     this.category$.next(this.selectedCategory());
   }
 

--- a/src/app/features/browse/category-detail/category-detail.page.html
+++ b/src/app/features/browse/category-detail/category-detail.page.html
@@ -1,0 +1,58 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-back-button defaultHref="/tabs/browse"></ion-back-button>
+    </ion-buttons>
+    <ion-title>{{ genreName() }}</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  @if (isLoading()) {
+    <div class="podcast-grid" aria-label="Loading category podcasts">
+      @for (s of skeletons; track s) {
+        <ion-card class="skeleton-card" aria-hidden="true">
+          <ion-skeleton-text [animated]="true" style="height: 120px"></ion-skeleton-text>
+          <ion-card-content>
+            <ion-skeleton-text [animated]="true" style="width: 85%; height: 16px"></ion-skeleton-text>
+            <ion-skeleton-text [animated]="true" style="width: 60%; height: 14px"></ion-skeleton-text>
+          </ion-card-content>
+        </ion-card>
+      }
+    </div>
+  }
+
+  @if (error() && !isLoading()) {
+    <wavely-empty-state
+      icon="alert-circle-outline"
+      title="Could not load this category"
+      [subtitle]="error()!"
+      actionLabel="Retry"
+      (action)="retry()">
+    </wavely-empty-state>
+  }
+
+  @if (!isLoading() && !error() && visiblePodcasts().length > 0) {
+    <div class="podcast-grid">
+      @for (podcast of visiblePodcasts(); track podcast.id) {
+        <wavely-podcast-card [podcast]="podcast" (cardClick)="navigateToPodcast($event)"></wavely-podcast-card>
+      }
+    </div>
+
+    @if (canLoadMore()) {
+      <div class="load-more-wrap">
+        <ion-button fill="outline" (click)="loadMore()">Load more</ion-button>
+      </div>
+    }
+  }
+
+  @if (!isLoading() && !error() && visiblePodcasts().length === 0) {
+    <wavely-empty-state
+      icon="search-outline"
+      title="No podcasts in this category"
+      subtitle="Try another category or check back later."
+      actionLabel="Refresh"
+      (action)="retry()">
+    </wavely-empty-state>
+  }
+</ion-content>

--- a/src/app/features/browse/category-detail/category-detail.page.scss
+++ b/src/app/features/browse/category-detail/category-detail.page.scss
@@ -1,0 +1,12 @@
+.podcast-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+  padding: 16px;
+}
+
+.load-more-wrap {
+  display: flex;
+  justify-content: center;
+  padding: 4px 16px 20px;
+}

--- a/src/app/features/browse/category-detail/category-detail.page.spec.ts
+++ b/src/app/features/browse/category-detail/category-detail.page.spec.ts
@@ -1,0 +1,94 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { BehaviorSubject, of } from 'rxjs';
+
+import { CategoryDetailPage } from './category-detail.page';
+import { PodcastApiService } from '../../../core/services/podcast-api.service';
+import { mockPodcast } from '../../../../testing/podcast-fixtures';
+
+describe('CategoryDetailPage', () => {
+  let fixture: ComponentFixture<CategoryDetailPage>;
+  let component: CategoryDetailPage;
+
+  const routeParams$ = new BehaviorSubject(convertToParamMap({ genreId: '1489' }));
+
+  const mockApi = {
+    getTrendingPodcasts: jest.fn().mockReturnValue(
+      of(
+        Array.from({ length: 35 }, (_, index) =>
+          mockPodcast({ id: `pod-${index + 1}` })
+        )
+      )
+    ),
+  };
+
+  const mockRouter = {
+    navigate: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CategoryDetailPage],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: routeParams$.asObservable(),
+          },
+        },
+        { provide: PodcastApiService, useValue: mockApi },
+        { provide: Router, useValue: mockRouter },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    })
+      .overrideComponent(CategoryDetailPage, {
+        set: { template: '<div></div>', imports: [] },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(CategoryDetailPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    routeParams$.next(convertToParamMap({ genreId: '1489' }));
+    TestBed.resetTestingModule();
+  });
+
+  it('loads podcasts for route genreId and maps category name', () => {
+    expect(component).toBeTruthy();
+    expect(mockApi.getTrendingPodcasts).toHaveBeenCalledWith(50, 1489);
+    expect((component as any).genreName()).toBe('News');
+  });
+
+  it('reacts to route param changes', () => {
+    routeParams$.next(convertToParamMap({ genreId: '1304' }));
+
+    expect(mockApi.getTrendingPodcasts).toHaveBeenCalledWith(50, 1304);
+    expect((component as any).genreName()).toBe('Education');
+  });
+
+  it('supports client-side load more pagination', () => {
+    expect((component as any).visiblePodcasts().length).toBe(12);
+    expect((component as any).canLoadMore()).toBe(true);
+
+    (component as any).loadMore();
+
+    expect((component as any).visiblePodcasts().length).toBe(24);
+    expect((component as any).canLoadMore()).toBe(true);
+
+    (component as any).loadMore();
+
+    expect((component as any).visiblePodcasts().length).toBe(35);
+    expect((component as any).canLoadMore()).toBe(false);
+  });
+
+  it('navigates to podcast detail when selecting a podcast', () => {
+    (component as any).navigateToPodcast(mockPodcast({ id: 'pod-99' }));
+
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/podcast', 'pod-99']);
+  });
+});

--- a/src/app/features/browse/category-detail/category-detail.page.ts
+++ b/src/app/features/browse/category-detail/category-detail.page.ts
@@ -1,0 +1,156 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import {
+  IonBackButton,
+  IonButton,
+  IonButtons,
+  IonCard,
+  IonCardContent,
+  IonContent,
+  IonHeader,
+  IonSkeletonText,
+  IonTitle,
+  IonToolbar,
+} from '@ionic/angular/standalone';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { addIcons } from 'ionicons';
+import { alertCircleOutline, refreshOutline, searchOutline } from 'ionicons/icons';
+import { catchError, of, switchMap, tap } from 'rxjs';
+
+import { Podcast } from '../../../core/models/podcast.model';
+import { PodcastApiService } from '../../../core/services/podcast-api.service';
+import { EmptyStateComponent } from '../../../shared/components/empty-state/empty-state.component';
+import { PodcastCardComponent } from '../../../shared/components/podcast-card/podcast-card.component';
+import { PODCAST_CATEGORIES } from '../browse.page';
+
+const SKELETON_COUNT = 6;
+const PAGE_SIZE = 12;
+
+@Component({
+  selector: 'wavely-category-detail',
+  standalone: true,
+  templateUrl: './category-detail.page.html',
+  styleUrls: ['./category-detail.page.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    IonBackButton,
+    IonButton,
+    IonButtons,
+    IonCard,
+    IonCardContent,
+    IonContent,
+    IonHeader,
+    IonSkeletonText,
+    IonTitle,
+    IonToolbar,
+    PodcastCardComponent,
+    EmptyStateComponent,
+  ],
+})
+export class CategoryDetailPage {
+  private readonly api = inject(PodcastApiService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly skeletons = Array.from({ length: SKELETON_COUNT });
+
+  protected readonly genreId = signal<number | null>(null);
+  protected readonly genreName = signal('Category');
+  protected readonly podcasts = signal<Podcast[]>([]);
+  protected readonly visibleCount = signal(PAGE_SIZE);
+  protected readonly isLoading = signal(false);
+  protected readonly error = signal<string | null>(null);
+
+  protected readonly visiblePodcasts = computed(() =>
+    this.podcasts().slice(0, this.visibleCount())
+  );
+  protected readonly canLoadMore = computed(
+    () => this.visiblePodcasts().length < this.podcasts().length
+  );
+
+  constructor() {
+    addIcons({ searchOutline, alertCircleOutline, refreshOutline });
+
+    this.route.paramMap
+      .pipe(
+        tap(() => {
+          this.isLoading.set(true);
+          this.error.set(null);
+          this.podcasts.set([]);
+          this.visibleCount.set(PAGE_SIZE);
+        }),
+        switchMap((params) => {
+          const rawGenreId = Number(params.get('genreId'));
+
+          if (!Number.isInteger(rawGenreId) || rawGenreId <= 0) {
+            this.genreId.set(null);
+            this.genreName.set('Category');
+            this.error.set('Invalid category. Please go back and try another one.');
+            return of([] as Podcast[]);
+          }
+
+          this.genreId.set(rawGenreId);
+          this.genreName.set(
+            PODCAST_CATEGORIES.find((category) => category.id === rawGenreId)?.name ??
+              'Category'
+          );
+
+          return this.api.getTrendingPodcasts(50, rawGenreId).pipe(
+            catchError(() => {
+              this.error.set('Could not load this category. Please try again.');
+              return of([] as Podcast[]);
+            })
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((podcasts) => {
+        this.podcasts.set(podcasts);
+        this.visibleCount.set(Math.min(PAGE_SIZE, podcasts.length));
+        this.isLoading.set(false);
+      });
+  }
+
+  protected loadMore(): void {
+    this.visibleCount.update((count) =>
+      Math.min(count + PAGE_SIZE, this.podcasts().length)
+    );
+  }
+
+  protected retry(): void {
+    const currentGenreId = this.genreId();
+    if (!currentGenreId) {
+      this.error.set('Invalid category. Please go back and try another one.');
+      return;
+    }
+
+    this.isLoading.set(true);
+    this.error.set(null);
+    this.api
+      .getTrendingPodcasts(50, currentGenreId)
+      .pipe(
+        catchError(() => {
+          this.error.set('Could not load this category. Please try again.');
+          return of([] as Podcast[]);
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((podcasts) => {
+        this.podcasts.set(podcasts);
+        this.visibleCount.set(Math.min(PAGE_SIZE, podcasts.length));
+        this.isLoading.set(false);
+      });
+  }
+
+  protected navigateToPodcast(podcast: Podcast): void {
+    this.router.navigate(['/podcast', podcast.id]);
+  }
+}

--- a/src/app/features/library/library.page.html
+++ b/src/app/features/library/library.page.html
@@ -2,7 +2,6 @@
   <ion-toolbar>
     <ion-title>Library</ion-title>
     <ion-buttons slot="end">
-      <!-- Dark mode toggle -->
       <ion-button id="theme-popover-trigger" aria-label="Change theme">
         <ion-icon slot="icon-only" name="moon-outline"></ion-icon>
       </ion-button>
@@ -10,9 +9,7 @@
         <ng-template>
           <ion-list>
             <ion-list-header>Appearance</ion-list-header>
-            <ion-radio-group
-              [value]="themeService.mode()"
-              (ionChange)="themeService.setMode($any($event).detail.value)">
+            <ion-radio-group [value]="themeService.mode()" (ionChange)="themeService.setMode($any($event).detail.value)">
               @for (opt of themeOptions; track opt) {
                 <ion-item>
                   <ion-icon [name]="opt.icon" slot="start"></ion-icon>
@@ -24,7 +21,6 @@
           </ion-list>
         </ng-template>
       </ion-popover>
-      <!-- User profile / sign-out -->
       @if (authStore.isAuthenticated()) {
         <ion-button id="profile-popover-trigger" [attr.aria-label]="'Account: ' + (authStore.displayName() ?? 'Profile')">
           @if (authStore.photoURL()) {
@@ -53,7 +49,6 @@
           </ng-template>
         </ion-popover>
       }
-      <!-- Add podcasts -->
       <ion-button (click)="navigateToBrowse()" aria-label="Add podcasts">
         <ion-icon slot="icon-only" name="add-outline"></ion-icon>
       </ion-button>
@@ -65,35 +60,59 @@
   <section class="library-section">
     <h2 class="section-title">Recently Played</h2>
 
+    <div class="history-filters" role="tablist" aria-label="History filters">
+      @for (filter of historyFilters; track filter.value) {
+        <ion-chip
+          [class.active]="historyStore.activeFilter() === filter.value"
+          [outline]="historyStore.activeFilter() !== filter.value"
+          (click)="selectFilter(filter.value)">
+          <ion-label>{{ filter.label }}</ion-label>
+        </ion-chip>
+      }
+    </div>
+
     @if (recentHistory().length === 0) {
-      <wavely-empty-state
-        icon="time-outline"
-        title="No listening history"
-        subtitle="Start an episode and your recent listens will appear here.">
-      </wavely-empty-state>
+      <wavely-empty-state icon="time-outline" title="No listening history" subtitle="Start an episode and your recent listens will appear here."></wavely-empty-state>
     } @else {
       <ion-list lines="none">
-        <ion-button slot="end" fill="clear" size="small" class="clear-history-btn" (click)="clearHistory()">
-          Clear history
-        </ion-button>
+        <ion-button slot="end" fill="clear" size="small" class="clear-history-btn" (click)="clearHistory()">Clear history</ion-button>
+        <p class="list-hint">Swipe left to mark played or unplayed</p>
 
         @for (entry of recentHistory(); track entry.episodeId) {
-          <ion-item>
-            <ion-thumbnail slot="start" class="history-thumbnail">
-              <img [src]="entry.imageUrl || '/default-artwork.svg'" [alt]="entry.episodeTitle" (error)="onImageError($event)" />
-            </ion-thumbnail>
-            <ion-label>
-              <h2>{{ entry.episodeTitle }}</h2>
-              <ion-note>{{ entry.podcastTitle }}</ion-note>
-              <div class="history-meta">
-                <ion-note>{{ formatTime(entry.position) }} / {{ formatTime(entry.duration) }}</ion-note>
-                @if (entry.completed) {
-                  <ion-note color="success">Completed</ion-note>
-                }
-              </div>
-              <ion-progress-bar [value]="progressValue(entry)"></ion-progress-bar>
-            </ion-label>
-          </ion-item>
+          <ion-item-sliding #historyItem>
+            <ion-item>
+              <ion-thumbnail slot="start" class="history-thumbnail">
+                <img [src]="entry.imageUrl || '/default-artwork.svg'" [alt]="entry.episodeTitle" (error)="onImageError($event)" />
+              </ion-thumbnail>
+              <ion-label>
+                <h2>{{ entry.episodeTitle }}</h2>
+                <ion-note>{{ entry.podcastTitle }}</ion-note>
+                <div class="history-meta">
+                  <ion-note>{{ formatTime(entry.position) }} / {{ formatTime(entry.duration) }}</ion-note>
+                  @if (entry.completed) {
+                    <ion-note color="success">Completed</ion-note>
+                  }
+                </div>
+                <ion-progress-bar [value]="progressValue(entry)"></ion-progress-bar>
+              </ion-label>
+              <ion-button
+                slot="end"
+                fill="clear"
+                size="small"
+                [color]="entry.completed ? 'medium' : 'success'"
+                [attr.aria-label]="entry.completed ? 'Mark as unplayed' : 'Mark as played'"
+                (click)="entry.completed ? markUnplayed(entry.episodeId) : markPlayed(entry.episodeId)">
+                {{ entry.completed ? 'Mark as unplayed' : 'Mark as played' }}
+              </ion-button>
+            </ion-item>
+            <ion-item-options side="end">
+              @if (entry.completed) {
+                <ion-item-option color="medium" (click)="markUnplayed(entry.episodeId); historyItem.close()">Mark as unplayed</ion-item-option>
+              } @else {
+                <ion-item-option color="success" (click)="markPlayed(entry.episodeId); historyItem.close()">Mark as played</ion-item-option>
+              }
+            </ion-item-options>
+          </ion-item-sliding>
         }
       </ion-list>
     }
@@ -101,7 +120,6 @@
 
   <section class="library-section">
     <h2 class="section-title">Subscriptions</h2>
-
     @if (store.subscriptions().length > 0) {
       <p class="list-hint">Swipe left to unsubscribe</p>
       <ion-list lines="full">
@@ -115,15 +133,7 @@
                 <h2>{{ podcast.title }}</h2>
                 <ion-note>{{ podcast.author }}</ion-note>
               </ion-label>
-              <ion-button
-                slot="end"
-                fill="clear"
-                color="medium"
-                size="small"
-                [attr.aria-label]="'Unsubscribe from ' + podcast.title"
-                (click)="$event.stopPropagation(); unsubscribe(podcast, slidingItem)">
-                ✕
-              </ion-button>
+              <ion-button slot="end" fill="clear" color="medium" size="small" [attr.aria-label]="'Unsubscribe from ' + podcast.title" (click)="$event.stopPropagation(); unsubscribe(podcast, slidingItem)">✕</ion-button>
             </ion-item>
             <ion-item-options side="end">
               <ion-item-option color="danger" (click)="unsubscribe(podcast, slidingItem)">Unsubscribe</ion-item-option>
@@ -132,13 +142,7 @@
         }
       </ion-list>
     } @else {
-      <wavely-empty-state
-        icon="library-outline"
-        title="No subscriptions yet"
-        subtitle="Browse podcasts and subscribe to build your library."
-        actionLabel="Browse Podcasts"
-        (action)="navigateToBrowse()">
-      </wavely-empty-state>
+      <wavely-empty-state icon="library-outline" title="No subscriptions yet" subtitle="Browse podcasts and subscribe to build your library." actionLabel="Browse Podcasts" (action)="navigateToBrowse()"></wavely-empty-state>
     }
   </section>
 </ion-content>

--- a/src/app/features/library/library.page.scss
+++ b/src/app/features/library/library.page.scss
@@ -9,6 +9,28 @@
   color: var(--wavely-on-surface);
 }
 
+.history-filters {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding: 0 16px 8px;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  ion-chip {
+    flex-shrink: 0;
+    cursor: pointer;
+  }
+
+  ion-chip.active {
+    --background: var(--ion-color-primary);
+    --color: var(--ion-color-primary-contrast);
+  }
+}
+
 .list-hint {
   margin: 4px 16px;
   font-size: 12px;

--- a/src/app/features/library/library.page.spec.ts
+++ b/src/app/features/library/library.page.spec.ts
@@ -9,7 +9,6 @@ jest.mock('@angular/fire/auth', () => ({
 import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
-
 import { LibraryPage } from './library.page';
 import { PodcastsStore } from '../../store/podcasts/podcasts.store';
 import { AuthStore } from '../../store/auth/auth.store';
@@ -24,25 +23,25 @@ describe('LibraryPage', () => {
   let component: LibraryPage;
 
   const mockStore = { subscriptions: signal([]) };
-  const mockAuthStore = {
-    user: signal({ uid: 'uid-1' }),
-    signOut: jest.fn().mockResolvedValue(undefined),
-  };
+  const mockAuthStore = { user: signal({ uid: 'uid-1' }), signOut: jest.fn().mockResolvedValue(undefined) };
   const mockHistoryStore = {
     entries: signal([]),
+    filteredEntries: signal([]),
     isLoading: signal(false),
+    activeFilter: signal<'all' | 'unplayed' | 'inProgress' | 'completed'>('all'),
     setLoading: jest.fn(),
     setEntries: jest.fn(),
     clear: jest.fn(),
+    setFilter: jest.fn(),
+    markPlayed: jest.fn(),
+    markUnplayed: jest.fn(),
   };
-  const mockThemeService = {
-    mode: signal<'system' | 'light' | 'dark'>('system'),
-    setMode: jest.fn(),
-  };
+  const mockThemeService = { mode: signal<'system' | 'light' | 'dark'>('system'), setMode: jest.fn() };
   const mockSyncService = { removeSubscription: jest.fn() };
   const mockHistorySyncService = {
     loadHistory: jest.fn().mockResolvedValue([]),
     clearHistory: jest.fn().mockResolvedValue(undefined),
+    updateEntry: jest.fn().mockResolvedValue(undefined),
   };
   const mockRouter = { navigate: jest.fn() };
 
@@ -59,9 +58,7 @@ describe('LibraryPage', () => {
         { provide: Router, useValue: mockRouter },
       ],
       schemas: [NO_ERRORS_SCHEMA],
-    })
-      .overrideComponent(LibraryPage, { set: { template: '<div></div>', imports: [] } })
-      .compileComponents();
+    }).overrideComponent(LibraryPage, { set: { template: '<div></div>', imports: [] } }).compileComponents();
 
     fixture = TestBed.createComponent(LibraryPage);
     component = fixture.componentInstance;
@@ -80,6 +77,29 @@ describe('LibraryPage', () => {
   it('loads history on init', () => {
     expect(mockHistoryStore.setLoading).toHaveBeenCalledWith(true);
     expect(mockHistorySyncService.loadHistory).toHaveBeenCalledWith('uid-1');
+  });
+
+  it('selectFilter delegates to historyStore.setFilter', () => {
+    (component as any).selectFilter('completed');
+    expect(mockHistoryStore.setFilter).toHaveBeenCalledWith('completed');
+  });
+
+  it('markPlayed updates store and sync service', async () => {
+    await (component as any).markPlayed('ep-1');
+
+    expect(mockHistoryStore.markPlayed).toHaveBeenCalledWith('ep-1');
+    expect(mockHistorySyncService.updateEntry).toHaveBeenCalledWith('ep-1', { completed: true }, 'uid-1');
+  });
+
+  it('markUnplayed updates store and sync service', async () => {
+    await (component as any).markUnplayed('ep-1');
+
+    expect(mockHistoryStore.markUnplayed).toHaveBeenCalledWith('ep-1');
+    expect(mockHistorySyncService.updateEntry).toHaveBeenCalledWith(
+      'ep-1',
+      { completed: false, position: 0 },
+      'uid-1'
+    );
   });
 
   it('delegates unsubscribe and signOut behaviors', async () => {

--- a/src/app/features/library/library.page.ts
+++ b/src/app/features/library/library.page.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
 import { Router } from '@angular/router';
 
 import {
@@ -23,6 +23,7 @@ import {
   IonRadio,
   IonThumbnail,
   IonProgressBar,
+  IonChip,
 } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import {
@@ -37,7 +38,7 @@ import {
 } from 'ionicons/icons';
 import { PodcastsStore } from '../../store/podcasts/podcasts.store';
 import { AuthStore } from '../../store/auth/auth.store';
-import { HistoryStore, HistoryEntry } from '../../store/history/history.store';
+import { HistoryStore, HistoryEntry, HistoryFilter } from '../../store/history/history.store';
 import { SubscriptionSyncService } from '../../core/services/subscription-sync.service';
 import { HistorySyncService } from '../../core/services/history-sync.service';
 import { ThemeService, ThemeMode } from '../../core/services/theme.service';
@@ -50,6 +51,7 @@ import { EmptyStateComponent } from '../../shared/components/empty-state/empty-s
   selector: 'wavely-library',
   templateUrl: './library.page.html',
   styleUrls: ['./library.page.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     IonHeader,
     IonToolbar,
@@ -72,6 +74,7 @@ import { EmptyStateComponent } from '../../shared/components/empty-state/empty-s
     IonRadio,
     IonThumbnail,
     IonProgressBar,
+    IonChip,
     EmptyStateComponent,
   ],
 })
@@ -85,7 +88,14 @@ export class LibraryPage {
   private readonly historySyncService = inject(HistorySyncService);
   private readonly router = inject(Router);
 
-  protected readonly recentHistory = computed(() => this.historyStore.entries().slice(0, 10));
+  protected readonly recentHistory = computed(() => this.historyStore.filteredEntries());
+
+  protected readonly historyFilters: { label: string; value: HistoryFilter }[] = [
+    { label: 'All', value: 'all' },
+    { label: 'Unplayed', value: 'unplayed' },
+    { label: 'In Progress', value: 'inProgress' },
+    { label: 'Completed', value: 'completed' },
+  ];
 
   protected readonly themeOptions: { label: string; value: ThemeMode; icon: string }[] = [
     { label: 'System default', value: 'system', icon: 'contrast-outline' },
@@ -122,6 +132,26 @@ export class LibraryPage {
       console.error('[LibraryPage] Failed to load history', err);
       this.historyStore.setLoading(false);
     }
+  }
+
+  protected selectFilter(filter: HistoryFilter): void {
+    this.historyStore.setFilter(filter);
+  }
+
+  protected async markPlayed(episodeId: string): Promise<void> {
+    this.historyStore.markPlayed(episodeId);
+    const uid = this.authStore.user()?.uid ?? '';
+    if (!uid) return;
+
+    await this.historySyncService.updateEntry(episodeId, { completed: true }, uid);
+  }
+
+  protected async markUnplayed(episodeId: string): Promise<void> {
+    this.historyStore.markUnplayed(episodeId);
+    const uid = this.authStore.user()?.uid ?? '';
+    if (!uid) return;
+
+    await this.historySyncService.updateEntry(episodeId, { completed: false, position: 0 }, uid);
   }
 
   protected navigateToPodcast(podcast: Podcast): void {

--- a/src/app/features/search/search.page.html
+++ b/src/app/features/search/search.page.html
@@ -10,12 +10,13 @@
       placeholder="Podcasts, shows, creators…"
       [debounce]="0"
       (ionInput)="onSearchInput($event)"
+      (ionFocus)="onSearchFocus()"
+      (ionBlur)="onSearchBlur()"
       (ionClear)="onSearchClear()"
       animated
       enterkeyhint="search"
       aria-label="Search podcasts">
     </ion-searchbar>
-
     @if (!globalSearch) {
       <button class="scope-toggle" (click)="toggleGlobalSearch()" type="button">
         <span class="scope-toggle__flag">{{ countryFlag }}</span>
@@ -31,14 +32,11 @@
     }
   </div>
 
-  <!-- Loading skeleton list -->
   @if (store.isLoading()) {
     <ion-list class="search-skeleton-list" lines="none">
       @for (s of skeletons; track s) {
         <ion-item>
-          <ion-thumbnail slot="start">
-            <ion-skeleton-text [animated]="true"></ion-skeleton-text>
-          </ion-thumbnail>
+          <ion-thumbnail slot="start"><ion-skeleton-text [animated]="true"></ion-skeleton-text></ion-thumbnail>
           <ion-label>
             <h3><ion-skeleton-text [animated]="true" style="width: 85%"></ion-skeleton-text></h3>
             <p><ion-skeleton-text [animated]="true" style="width: 60%"></ion-skeleton-text></p>
@@ -48,7 +46,6 @@
     </ion-list>
   }
 
-  <!-- Results -->
   @if (!store.isLoading() && store.searchResults().length > 0) {
     <div class="podcast-grid">
       @for (podcast of store.searchResults(); track podcast) {
@@ -57,23 +54,12 @@
     </div>
   }
 
-  <!-- Error -->
   @if (store.error() && !store.isLoading()) {
-    <wavely-empty-state
-      icon="alert-circle-outline"
-      title="Search failed"
-      [subtitle]="store.error()!"
-      actionLabel="Retry"
-      (action)="retrySearch()">
-    </wavely-empty-state>
+    <wavely-empty-state icon="alert-circle-outline" title="Search failed" [subtitle]="store.error()!" actionLabel="Retry" (action)="retrySearch()"></wavely-empty-state>
   }
 
-  <!-- Empty: typed a query but got nothing -->
   @if (!store.isLoading() && !store.error() && displayQuery && store.searchResults().length === 0) {
-    <wavely-empty-state
-      icon="search-outline"
-      title="No podcasts found"
-      [subtitle]="'No results for &quot;' + displayQuery + '&quot;' + (!globalSearch ? ' in your region.' : '.')">
+    <wavely-empty-state icon="search-outline" title="No podcasts found" [subtitle]="'No results for &quot;' + displayQuery + '&quot;' + (!globalSearch ? ' in your region.' : '.')">
       @if (!globalSearch) {
         <p class="global-search-hint">
           <button class="inline-link" (click)="toggleGlobalSearch()" type="button">Search all regions</button>
@@ -82,12 +68,32 @@
     </wavely-empty-state>
   }
 
-  <!-- Idle: nothing typed yet -->
   @if (!store.isLoading() && !displayQuery) {
     <div class="state-message state-message--idle">
-      <ion-text color="medium">
-        <p>Search for your favourite podcasts</p>
-      </ion-text>
+      @if (shouldShowSuggestions()) {
+        <section class="recent-searches recent-searches--focused">
+          <header class="recent-searches__header">
+            <h2>Recent Searches</h2>
+            <button class="recent-searches__clear" (click)="clearRecentSearches()" type="button">
+              <ion-icon name="trash-outline" aria-hidden="true"></ion-icon>
+              Clear all
+            </button>
+          </header>
+          <div class="recent-searches__chips">
+            @for (term of recentSearches; track term) {
+              <ion-chip class="recent-searches__chip" (click)="useSuggestion(term)">
+                <ion-icon name="time-outline" slot="start" aria-hidden="true"></ion-icon>
+                <ion-label>{{ term }}</ion-label>
+                <button class="recent-searches__remove" aria-label="Remove {{ term }}" type="button" (click)="removeRecentSearch(term, $event)">
+                  <ion-icon name="close-circle-outline" aria-hidden="true"></ion-icon>
+                </button>
+              </ion-chip>
+            }
+          </div>
+        </section>
+      } @else {
+        <ion-text color="medium"><p>Search for your favourite podcasts</p></ion-text>
+      }
     </div>
   }
 </ion-content>

--- a/src/app/features/search/search.page.scss
+++ b/src/app/features/search/search.page.scss
@@ -59,7 +59,7 @@
 }
 
 .state-message {
-  padding: 48px 32px;
+  padding: 24px 16px 32px;
   text-align: center;
 
   ion-text p {
@@ -70,5 +70,69 @@
   &--idle ion-text p {
     font-size: 16px;
     color: var(--wavely-on-surface-muted);
+  }
+}
+
+.recent-searches {
+  text-align: left;
+  background: var(--ion-color-light);
+  border-radius: 16px;
+  padding: 16px;
+  border: 1px solid var(--ion-color-step-100, rgba(255, 255, 255, 0.06));
+
+  &--focused {
+    border-color: var(--ion-color-primary);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--ion-color-primary) 30%, transparent);
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 12px;
+
+    h2 {
+      margin: 0;
+      font-size: 15px;
+      font-weight: 700;
+      color: var(--wavely-on-surface);
+    }
+  }
+
+  &__clear {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: none;
+    background: transparent;
+    color: var(--ion-color-primary);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 4px 0;
+  }
+
+  &__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  &__chip {
+    margin: 0;
+  }
+
+  &__remove {
+    border: none;
+    background: transparent;
+    color: var(--ion-color-medium);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 4px;
+    padding: 0;
+    cursor: pointer;
+    font-size: 18px;
   }
 }

--- a/src/app/features/search/search.page.spec.ts
+++ b/src/app/features/search/search.page.spec.ts
@@ -2,9 +2,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
-
 import { SearchPage } from './search.page';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
+import { SearchHistoryService } from '../../core/services/search-history.service';
 import { PodcastsStore } from '../../store/podcasts/podcasts.store';
 import { mockPodcast } from '../../../testing/podcast-fixtures';
 
@@ -13,6 +13,7 @@ describe('SearchPage', () => {
   let component: SearchPage;
   let api: { searchPodcasts: jest.Mock; detectCountry: jest.Mock };
   let router: { navigate: jest.Mock };
+  let searchHistory: { getHistory: jest.Mock; addQuery: jest.Mock; removeQuery: jest.Mock; clearAll: jest.Mock };
 
   const store = {
     query: signal(''),
@@ -32,28 +33,30 @@ describe('SearchPage', () => {
       detectCountry: jest.fn().mockReturnValue('us'),
     };
     router = { navigate: jest.fn() };
+    searchHistory = {
+      getHistory: jest.fn().mockReturnValue(['angular']),
+      addQuery: jest.fn(),
+      removeQuery: jest.fn(),
+      clearAll: jest.fn(),
+    };
 
     await TestBed.configureTestingModule({
       imports: [SearchPage],
       providers: [
         { provide: PodcastApiService, useValue: api },
         { provide: PodcastsStore, useValue: store },
+        { provide: SearchHistoryService, useValue: searchHistory },
         { provide: Router, useValue: router },
       ],
       schemas: [NO_ERRORS_SCHEMA],
-    })
-      .overrideComponent(SearchPage, { set: { template: '<div></div>', imports: [] } })
-      .compileComponents();
+    }).overrideComponent(SearchPage, { set: { template: '<div></div>', imports: [] } }).compileComponents();
 
     fixture = TestBed.createComponent(SearchPage);
     component = fixture.componentInstance;
     fixture.detectChanges();
   }
 
-  beforeEach(() => {
-    jest.useFakeTimers();
-  });
-
+  beforeEach(() => { jest.useFakeTimers(); });
   afterEach(() => {
     jest.useRealTimers();
     jest.clearAllMocks();
@@ -67,7 +70,6 @@ describe('SearchPage', () => {
 
   it('debounces search input and stores search results', async () => {
     await createComponent();
-
     (component as any).onSearchInput({ detail: { value: 'angular' } } as never);
     jest.advanceTimersByTime(300);
 
@@ -76,18 +78,33 @@ describe('SearchPage', () => {
     expect(store.setSearchResults).toHaveBeenCalledWith(expect.any(Array), 'angular');
   });
 
+  it('calls addQuery after successful search', async () => {
+    await createComponent();
+    (component as any).onSearchInput({ detail: { value: 'rxjs' } } as never);
+    jest.advanceTimersByTime(300);
+
+    expect(searchHistory.addQuery).toHaveBeenCalledWith('rxjs');
+  });
+
   it('clears results when search is cleared', async () => {
     await createComponent();
-
     (component as any).onSearchClear();
     jest.advanceTimersByTime(300);
 
     expect(store.setSearchResults).toHaveBeenCalledWith([], '');
   });
 
+  it('tapping suggestion triggers search', async () => {
+    await createComponent();
+    (component as any).useSuggestion('ionic');
+    jest.advanceTimersByTime(300);
+
+    expect(store.setQuery).toHaveBeenCalledWith('ionic');
+    expect(api.searchPodcasts).toHaveBeenCalledWith('ionic', 'us');
+  });
+
   it('navigates to podcast detail', async () => {
     await createComponent();
-
     (component as any).navigateToPodcast(mockPodcast({ id: 'pod-5' }));
 
     expect(router.navigate).toHaveBeenCalledWith(['/podcast', 'pod-5']);

--- a/src/app/features/search/search.page.ts
+++ b/src/app/features/search/search.page.ts
@@ -1,6 +1,5 @@
-import { Component, OnDestroy, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, ViewChild, inject } from '@angular/core';
 import { Router } from '@angular/router';
-
 import {
   IonHeader,
   IonToolbar,
@@ -13,12 +12,15 @@ import {
   IonLabel,
   IonSkeletonText,
   IonThumbnail,
+  IonChip,
+  IonIcon,
   SearchbarCustomEvent,
 } from '@ionic/angular/standalone';
 import { Subject, debounceTime, distinctUntilChanged, switchMap, of, takeUntil, catchError, map } from 'rxjs';
 import { addIcons } from 'ionicons';
-import { alertCircleOutline, refreshOutline, searchOutline } from 'ionicons/icons';
+import { alertCircleOutline, closeCircleOutline, refreshOutline, searchOutline, timeOutline, trashOutline } from 'ionicons/icons';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
+import { SearchHistoryService } from '../../core/services/search-history.service';
 import { PodcastsStore } from '../../store/podcasts/podcasts.store';
 import { PodcastCardComponent } from '../../shared/components/podcast-card/podcast-card.component';
 import { Podcast } from '../../core/models/podcast.model';
@@ -29,8 +31,10 @@ const DEBOUNCE_MS = 300;
 
 @Component({
   selector: 'wavely-search',
+  standalone: true,
   templateUrl: './search.page.html',
   styleUrls: ['./search.page.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     IonHeader,
     IonToolbar,
@@ -43,72 +47,77 @@ const DEBOUNCE_MS = 300;
     IonLabel,
     IonSkeletonText,
     IonThumbnail,
+    IonChip,
+    IonIcon,
     PodcastCardComponent,
     EmptyStateComponent,
   ],
 })
 export class SearchPage implements OnDestroy {
+  @ViewChild(IonSearchbar) private searchbar?: IonSearchbar;
+
   private readonly api = inject(PodcastApiService);
+  private readonly searchHistory = inject(SearchHistoryService);
   protected readonly store = inject(PodcastsStore);
   private readonly router = inject(Router);
 
   protected readonly skeletons = Array.from({ length: SKELETON_COUNT });
-  protected readonly skeletonPodcast: Podcast = {
-    id: '',
-    title: '',
-    author: '',
-    description: '',
-    artworkUrl: '',
-    feedUrl: '',
-    genres: [],
-  };
-
-  /** The ISO country code detected from the browser locale (e.g. "es", "us"). */
+  protected readonly skeletonPodcast: Podcast = { id: '', title: '', author: '', description: '', artworkUrl: '', feedUrl: '', genres: [] };
   protected readonly detectedCountry: string;
-  /** When true, pass no country to iTunes so it searches all stores globally. */
   protected globalSearch = false;
-  /**
-   * Tracks what the user has typed. This is the *display* value shown in
-   * no-results / idle messages. It is NOT fed back into ion-searchbar to
-   * avoid the controlled-input cycle that drops characters.
-   */
   protected displayQuery = '';
+  protected isSearchFocused = false;
+  protected recentSearches: string[] = [];
 
   private readonly search$ = new Subject<string>();
   private readonly destroy$ = new Subject<void>();
 
   constructor() {
     this.detectedCountry = this.api.detectCountry();
-    addIcons({ searchOutline, alertCircleOutline, refreshOutline });
+    this.recentSearches = this.searchHistory.getHistory();
+    addIcons({
+      searchOutline,
+      alertCircleOutline,
+      refreshOutline,
+      timeOutline,
+      closeCircleOutline,
+      trashOutline,
+    });
 
-    this.search$
-      .pipe(
-        debounceTime(DEBOUNCE_MS),
-        distinctUntilChanged(),
-        switchMap((term) => {
-          if (!term.trim()) {
-            this.store.setSearchResults([], '');
-            return of(null);
-          }
-          this.store.setLoading(true);
-          const country = this.globalSearch ? undefined : this.detectedCountry;
-          // Bind the originating term alongside results to avoid stale-query race
-          return this.api.searchPodcasts(term, country).pipe(
-            map((results) => ({ term, results })),
-            // catchError inside switchMap keeps the outer stream alive after failures
-            catchError(() => {
-              this.store.setError('Search failed. Please try again.');
-              return of(null);
-            })
-          );
-        }),
-        takeUntil(this.destroy$)
-      )
-      .subscribe((payload) => {
-        if (payload !== null) {
-          this.store.setSearchResults(payload.results, payload.term);
+    this.search$.pipe(
+      debounceTime(DEBOUNCE_MS),
+      distinctUntilChanged(),
+      switchMap((term) => {
+        const normalizedTerm = term.trim();
+        if (!normalizedTerm) {
+          this.store.setQuery('');
+          this.store.setSearchResults([], '');
+          return of(null);
         }
-      });
+
+        this.store.setLoading(true);
+        const country = this.globalSearch ? undefined : this.detectedCountry;
+
+        return this.api.searchPodcasts(normalizedTerm, country).pipe(
+          map((results) => ({ term: normalizedTerm, results })),
+          catchError(() => {
+            this.store.setError('Search failed. Please try again.');
+            return of(null);
+          })
+        );
+      }),
+      takeUntil(this.destroy$)
+    ).subscribe((payload) => {
+      if (payload === null) {
+        return;
+      }
+
+      this.store.setSearchResults(payload.results, payload.term);
+      if (payload.results.length > 0) {
+        this.searchHistory.addQuery(payload.term);
+        this.recentSearches = this.searchHistory.getHistory();
+      }
+    });
   }
 
   ngOnDestroy(): void {
@@ -123,10 +132,40 @@ export class SearchPage implements OnDestroy {
     this.search$.next(term);
   }
 
+  protected onSearchFocus(): void {
+    this.isSearchFocused = true;
+    this.recentSearches = this.searchHistory.getHistory();
+  }
+
+  protected onSearchBlur(): void {
+    this.isSearchFocused = false;
+  }
+
   protected onSearchClear(): void {
     this.displayQuery = '';
-    // Emit empty string immediately so switchMap cancels any in-flight request
     this.search$.next('');
+  }
+
+  protected useSuggestion(term: string): void {
+    this.displayQuery = term;
+    this.store.setQuery(term);
+    if (this.searchbar) this.searchbar.value = term;
+    this.search$.next(term);
+  }
+
+  protected removeRecentSearch(term: string, event: Event): void {
+    event.stopPropagation();
+    this.searchHistory.removeQuery(term);
+    this.recentSearches = this.searchHistory.getHistory();
+  }
+
+  protected clearRecentSearches(): void {
+    this.searchHistory.clearAll();
+    this.recentSearches = [];
+  }
+
+  protected shouldShowSuggestions(): boolean {
+    return this.isSearchFocused && !this.displayQuery.trim() && this.recentSearches.length > 0;
   }
 
   protected toggleGlobalSearch(): void {
@@ -138,9 +177,7 @@ export class SearchPage implements OnDestroy {
 
   protected retrySearch(): void {
     const query = this.store.searchQuery();
-    if (!query.trim()) {
-      return;
-    }
+    if (!query.trim()) return;
     this.search$.next(query);
   }
 
@@ -148,16 +185,9 @@ export class SearchPage implements OnDestroy {
     this.router.navigate(['/podcast', podcast.id]);
   }
 
-  /** Returns the flag emoji for the detected country (e.g. 🇪🇸 for "es"). */
   protected get countryFlag(): string {
     const code = this.detectedCountry;
-    if (!/^[a-z]{2}$/.test(code)) {
-      return '🌍';
-    }
-
-    return code
-      .split('')
-      .map((c) => String.fromCodePoint(c.charCodeAt(0) - 97 + 0x1f1e6))
-      .join('');
+    if (!/^[a-z]{2}$/.test(code)) return '🌍';
+    return code.split('').map((c) => String.fromCodePoint(c.charCodeAt(0) - 97 + 0x1f1e6)).join('');
   }
 }

--- a/src/app/store/history/history.store.spec.ts
+++ b/src/app/store/history/history.store.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { HistoryStore, type HistoryEntry } from './history.store';
+import { HistoryStore, type HistoryEntry, type HistoryFilter } from './history.store';
 
 const makeEntry = (overrides: Partial<HistoryEntry> = {}): HistoryEntry => ({
   episodeId: 'ep-1',
@@ -74,5 +74,82 @@ describe('HistoryStore', () => {
 
     expect(store.entries()).toEqual([]);
     expect(store.isLoading()).toBe(false);
+  });
+
+  it('has initial activeFilter of "all"', () => {
+    expect(store.activeFilter()).toBe('all');
+  });
+
+  it('setFilter updates activeFilter', () => {
+    store.setFilter('completed');
+    expect(store.activeFilter()).toBe('completed');
+
+    store.setFilter('all');
+    expect(store.activeFilter()).toBe('all');
+  });
+
+  describe('filteredEntries', () => {
+    const unplayed = makeEntry({ episodeId: 'ep-unplayed', position: 0, completed: false });
+    const inProgress = makeEntry({ episodeId: 'ep-progress', position: 45, completed: false });
+    const completed = makeEntry({ episodeId: 'ep-done', position: 120, completed: true });
+
+    beforeEach(() => {
+      store.setEntries([unplayed, inProgress, completed]);
+    });
+
+    it('"all" returns every entry', () => {
+      store.setFilter('all');
+      expect(store.filteredEntries()).toHaveLength(3);
+    });
+
+    it('"unplayed" returns entries with position 0 and not completed', () => {
+      store.setFilter('unplayed');
+      const result = store.filteredEntries();
+      expect(result).toHaveLength(1);
+      expect(result[0].episodeId).toBe('ep-unplayed');
+    });
+
+    it('"inProgress" returns entries with position > 0 and not completed', () => {
+      store.setFilter('inProgress');
+      const result = store.filteredEntries();
+      expect(result).toHaveLength(1);
+      expect(result[0].episodeId).toBe('ep-progress');
+    });
+
+    it('"completed" returns entries where completed is true', () => {
+      store.setFilter('completed');
+      const result = store.filteredEntries();
+      expect(result).toHaveLength(1);
+      expect(result[0].episodeId).toBe('ep-done');
+    });
+  });
+
+  it('markPlayed sets completed true on the matching entry', () => {
+    store.setEntries([
+      makeEntry({ episodeId: 'ep-1', completed: false, position: 30 }),
+      makeEntry({ episodeId: 'ep-2', completed: false, position: 0 }),
+    ]);
+
+    store.markPlayed('ep-1');
+
+    const ep1 = store.entries().find((e) => e.episodeId === 'ep-1')!;
+    const ep2 = store.entries().find((e) => e.episodeId === 'ep-2')!;
+    expect(ep1.completed).toBe(true);
+    expect(ep2.completed).toBe(false);
+  });
+
+  it('markUnplayed sets completed false and position 0 on the matching entry', () => {
+    store.setEntries([
+      makeEntry({ episodeId: 'ep-1', completed: true, position: 120 }),
+      makeEntry({ episodeId: 'ep-2', completed: true, position: 60 }),
+    ]);
+
+    store.markUnplayed('ep-1');
+
+    const ep1 = store.entries().find((e) => e.episodeId === 'ep-1')!;
+    const ep2 = store.entries().find((e) => e.episodeId === 'ep-2')!;
+    expect(ep1.completed).toBe(false);
+    expect(ep1.position).toBe(0);
+    expect(ep2.completed).toBe(true);
   });
 });

--- a/src/app/store/history/history.store.ts
+++ b/src/app/store/history/history.store.ts
@@ -1,4 +1,7 @@
-import { patchState, signalStore, withMethods, withState } from '@ngrx/signals';
+import { computed } from '@angular/core';
+import { patchState, signalStore, withComputed, withMethods, withState } from '@ngrx/signals';
+
+export type HistoryFilter = 'all' | 'unplayed' | 'inProgress' | 'completed';
 
 export interface HistoryEntry {
   episodeId: string;
@@ -14,11 +17,13 @@ export interface HistoryEntry {
 export interface HistoryState {
   entries: HistoryEntry[];
   isLoading: boolean;
+  filter: HistoryFilter;
 }
 
 const initialState: HistoryState = {
   entries: [],
   isLoading: false,
+  filter: 'all',
 };
 
 const sortByLastPlayed = (entries: HistoryEntry[]): HistoryEntry[] =>
@@ -27,6 +32,23 @@ const sortByLastPlayed = (entries: HistoryEntry[]): HistoryEntry[] =>
 export const HistoryStore = signalStore(
   { providedIn: 'root' },
   withState(initialState),
+  withComputed((store) => ({
+    filteredEntries: computed(() => {
+      const f = store.filter();
+      const entries = store.entries();
+      switch (f) {
+        case 'unplayed':
+          return entries.filter((e) => e.position === 0 && !e.completed);
+        case 'inProgress':
+          return entries.filter((e) => e.position > 0 && !e.completed);
+        case 'completed':
+          return entries.filter((e) => e.completed);
+        default:
+          return entries;
+      }
+    }),
+    activeFilter: computed(() => store.filter()),
+  })),
   withMethods((store) => ({
     setLoading(loading: boolean): void {
       patchState(store, { isLoading: loading });
@@ -39,6 +61,21 @@ export const HistoryStore = signalStore(
       patchState(store, {
         entries: sortByLastPlayed([...withoutCurrent, entry]),
       });
+    },
+    setFilter(filter: HistoryFilter): void {
+      patchState(store, { filter });
+    },
+    markPlayed(episodeId: string): void {
+      const updated = store.entries().map((e) =>
+        e.episodeId === episodeId ? { ...e, completed: true, position: e.duration || e.position } : e
+      );
+      patchState(store, { entries: sortByLastPlayed(updated) });
+    },
+    markUnplayed(episodeId: string): void {
+      const updated = store.entries().map((e) =>
+        e.episodeId === episodeId ? { ...e, completed: false, position: 0 } : e
+      );
+      patchState(store, { entries: sortByLastPlayed(updated) });
     },
     clear(): void {
       patchState(store, { entries: [], isLoading: false });


### PR DESCRIPTION
## Summary
Squash-reconcile promotion of Discovery & Library milestone to production.

## Changes
- feat(search): recent searches history with localStorage persistence (closes #38)
- feat(library): episode filtering (unplayed/in-progress/all) (closes #39)  
- feat(browse): featured section + category detail pages (closes #40)
- fix(e2e): server routes and Playwright test fixes for new browse navigation

## Testing
- [x] Unit tests: 233 passing
- [x] E2E: all passing (ran on promote-staging branch, staging env)
- [x] Manually tested on web

## Note
This is a squash-reconcile PR because staging and main have diverged commit histories from prior squash merges. The branch is created from main HEAD with staging content applied via `git checkout origin/staging -- .`