### PR TITLE
fix(e2e): cherry-pick CI fixes from staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ src/environments/environment.staging.ts
 
 # E2E auth state — contains browser storage with Firebase auth tokens
 e2e/.auth/user.json
+playwright-report/

--- a/e2e/src/home.spec.ts
+++ b/e2e/src/home.spec.ts
@@ -127,7 +127,12 @@ test.describe('Home page', () => {
     });
 
     await page.goto(`/podcast/${SUBSCRIPTION_PODCAST.id}`);
-    await page.getByRole('button', { name: /^subscribe$/i }).click();
+    await expect(page.locator('.podcast-header:not(.skeleton-header)')).toBeVisible({ timeout: 15000 });
+    await page.waitForFunction(() => (window as any)['__e2eAuthReady'] === true, { timeout: 15000 });
+
+    await page.locator('ion-button').filter({ hasText: /\bSubscribe\b/i }).click();
+    // Wait for the optimistic update to reflect in the UI before navigating
+    await expect(page.locator('ion-button').filter({ hasText: /\bSubscribed\b/i })).toBeVisible({ timeout: 10000 });
 
     // Navigate within the SPA to preserve PodcastsStore state (page.goto would reload,
     // potentially losing the subscription before the Firestore write completes).
@@ -135,6 +140,6 @@ test.describe('Home page', () => {
     void page.evaluate((u: string) => (window as any)['__e2eNavigate'](u), '/tabs/home').catch(() => {});
     await page.waitForURL('/tabs/home', { timeout: 10000 });
     await expect(page.getByRole('heading', { name: 'My Podcasts' })).toBeVisible({ timeout: 10000 });
-    await expect(page.locator('.podcast-card__title', { hasText: SUBSCRIPTION_PODCAST.title })).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('wavely-podcast-card').filter({ hasText: SUBSCRIPTION_PODCAST.title })).toBeVisible({ timeout: 10000 });
   });
 });

--- a/e2e/src/subscription.spec.ts
+++ b/e2e/src/subscription.spec.ts
@@ -65,18 +65,23 @@ test.describe.serial('Subscriptions', () => {
     await mockPodcastEndpoints(page, podcast);
 
     await page.goto(`/podcast/${podcast.id}`);
-    await page.getByRole('button', { name: /^subscribe$/i }).click();
+    await expect(page.locator('.podcast-header:not(.skeleton-header)')).toBeVisible({ timeout: 15000 });
+
+    // Wait for Firebase Auth to restore the session. Without this, clicking
+    // Subscribe before auth resolves causes a race: the subscription is added
+    // locally (uid=null, no Firestore write), then AuthStore.init() processes
+    // the restored user and calls clearSubscriptions(), wiping it.
+    await page.waitForFunction(() => (window as any)['__e2eAuthReady'] === true, { timeout: 15000 });
+
+    await page.locator('ion-button').filter({ hasText: /\bSubscribe\b/i }).click();
+    await expect(page.locator('ion-button').filter({ hasText: /\bSubscribed\b/i })).toBeVisible({ timeout: 10000 });
 
     // SPA navigation preserves PodcastsStore state; page.goto would reload and
     // lose the subscription before the Firestore write completes.
-    // Fire-and-forget: Angular router navigation destroys the JS execution context,
-    // so page.evaluate rejects with "Execution context was destroyed" — that's expected.
     void page.evaluate((u: string) => (window as any)['__e2eNavigate'](u), '/tabs/library').catch(() => {});
     await page.waitForURL('/tabs/library');
-    // ion-title doesn't expose role="heading" — match via locator
     await expect(page.locator('ion-title').filter({ hasText: 'Library' })).toBeVisible();
-    // Library renders subscriptions as ion-item with ion-label h2 (not wavely-podcast-card)
-    await expect(page.locator('ion-label h2').filter({ hasText: podcast.title })).toBeVisible();
+    await expect(page.locator('ion-item-sliding').filter({ hasText: podcast.title })).toBeVisible({ timeout: 10000 });
   });
 
   test('unsubscribe removes podcast from library', async ({ page }) => {
@@ -84,23 +89,19 @@ test.describe.serial('Subscriptions', () => {
     await mockPodcastEndpoints(page, podcast);
 
     await page.goto(`/podcast/${podcast.id}`);
-    await page.getByRole('button', { name: /^subscribe$/i }).click();
-    // Wait for the optimistic update to reflect in the UI before navigating
-    // (button changes to 'Subscribed' as soon as the store adds the podcast)
-    await expect(page.getByRole('button', { name: /^subscribed$/i })).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.podcast-header:not(.skeleton-header)')).toBeVisible({ timeout: 15000 });
+    await page.waitForFunction(() => (window as any)['__e2eAuthReady'] === true, { timeout: 15000 });
+
+    await page.locator('ion-button').filter({ hasText: /\bSubscribe\b/i }).click();
+    await expect(page.locator('ion-button').filter({ hasText: /\bSubscribed\b/i })).toBeVisible({ timeout: 10000 });
 
     void page.evaluate((u: string) => (window as any)['__e2eNavigate'](u), '/tabs/library').catch(() => {});
     await page.waitForURL('/tabs/library');
     await expect(page.locator('ion-title').filter({ hasText: 'Library' })).toBeVisible();
-    await expect(page.locator('ion-label h2').filter({ hasText: podcast.title })).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('ion-item-sliding').filter({ hasText: podcast.title })).toBeVisible({ timeout: 15000 });
 
-    // ion-button[aria-label] is unreliable after Ionic hydration: Ionic forwards
-    // the host aria-label to the shadow <button> and clears the host attribute.
-    // Use ion-button[slot="end"] scoped to the podcast's ion-item-sliding instead.
-    const podcastItem = page.locator('ion-item-sliding').filter({
-      has: page.locator('ion-label h2').filter({ hasText: podcast.title }),
-    });
+    const podcastItem = page.locator('ion-item-sliding').filter({ hasText: podcast.title });
     await podcastItem.locator('ion-button[slot="end"]').click();
-    await expect(page.locator('ion-label h2').filter({ hasText: podcast.title })).toHaveCount(0);
+    await expect(page.locator('ion-item-sliding').filter({ hasText: podcast.title })).toHaveCount(0);
   });
 });

--- a/src/app/app.routes.server.e2e.ts
+++ b/src/app/app.routes.server.e2e.ts
@@ -21,11 +21,11 @@ export const serverRoutes: ServerRoute[] = [
   },
   {
     path: 'podcast/:id',
-    renderMode: RenderMode.Server,
+    renderMode: RenderMode.Client,
   },
   {
     path: 'episode/:id',
-    renderMode: RenderMode.Server,
+    renderMode: RenderMode.Client,
   },
   {
     path: 'publisher/:artistId',

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,7 +1,10 @@
 import { Component, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+import { collection, Firestore, getDocs } from '@angular/fire/firestore';
+import { filter, take } from 'rxjs';
 import { AudioService } from './core/services/audio.service';
+import { AuthService } from './core/auth/auth.service';
 import { AuthStore } from './store/auth/auth.store';
 import { environment } from '../environments/environment';
 
@@ -21,12 +24,31 @@ export class App {
 
   constructor() {
     this.authStore.init();
-    // Expose SPA navigation helper for E2E tests. This allows Playwright to
-    // navigate via Angular Router without triggering a full page reload,
-    // preserving in-memory store state (PlayerStore, PodcastsStore).
+
     if (environment.useEmulators) {
+      const authService = inject(AuthService);
+      const firestore = inject(Firestore);
+
+      // Expose SPA navigation helper for E2E tests. This allows Playwright to
+      // navigate via Angular Router without triggering a full page reload,
+      // preserving in-memory store state (PlayerStore, PodcastsStore).
       (window as any)['__e2eNavigate'] = (url: string) =>
         this.router.navigate([url]);
+
+      // Signal to E2E tests when auth AND Firestore are fully ready.
+      // After AuthStore processes auth state (clearSubscriptions + loadFromFirestore),
+      // we verify Firestore has received the auth token by performing a test read.
+      // Without this, clicking Subscribe before Firestore has the token causes
+      // setDoc to fail with PERMISSION_DENIED, triggering a rollback.
+      authService.user$.pipe(
+        filter((u) => u !== null),
+        take(1),
+      ).subscribe(async (user) => {
+        try {
+          await getDocs(collection(firestore, 'users', user!.uid, 'subscriptions'));
+        } catch { /* just needed to wait for Firestore auth propagation */ }
+        (window as any)['__e2eAuthReady'] = true;
+      });
     }
   }
 }

--- a/src/app/core/services/podcast-api.service.ts
+++ b/src/app/core/services/podcast-api.service.ts
@@ -128,7 +128,7 @@ export class PodcastApiService {
       genres: raw.genres ?? [],
       episodeCount: raw.trackCount,
       latestReleaseDate: raw.releaseDate,
-      artistId: raw.artistId != null ? String(raw.artistId) : undefined,
+      ...(raw.artistId != null && { artistId: String(raw.artistId) }),
     };
   }
 

--- a/src/app/core/services/subscription-sync.service.ts
+++ b/src/app/core/services/subscription-sync.service.ts
@@ -53,7 +53,12 @@ export class SubscriptionSyncService {
     if (!uid) return;
     try {
       const docRef = doc(this.firestore, 'users', uid, 'subscriptions', podcast.id);
-      await setDoc(docRef, { ...podcast });
+      // Strip undefined values — Firestore rejects them as "Unsupported field value"
+      const data: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(podcast)) {
+        if (value !== undefined) data[key] = value;
+      }
+      await setDoc(docRef, data);
     } catch (err) {
       console.error('[SubscriptionSyncService] Failed to persist subscription', err);
       // Rollback optimistic update

--- a/src/app/features/podcast-detail/podcast-detail.page.ts
+++ b/src/app/features/podcast-detail/podcast-detail.page.ts
@@ -121,6 +121,11 @@ export class PodcastDetailPage {
     } else {
       this.syncService.addSubscription(this.podcast, uid);
     }
+    // Force synchronous change detection for the optimistic UI update.
+    // addSubscription() is async (await setDoc) — Zone.js delays tick() until
+    // the Firestore write resolves. Using detectChanges() ensures the button
+    // shows "Subscribed" immediately, before the network call completes.
+    this.cdr.detectChanges();
   }
 
   protected playEpisode(episode: Episode): void {


### PR DESCRIPTION
Cherry-pick E2E fixes that were applied during staging promotion:

- Strip undefined values before Firestore setDoc (root cause of subscription test failures)
- Use detectChanges() for synchronous optimistic UI in podcast detail
- Add __e2eAuthReady flag with Firestore auth verification
- Use client render mode for E2E detail routes
- Add playwright-report/ to .gitignore