### PR TITLE
fix: promote track-by-id + lookupPodcast guard to main

### DIFF
--- a/src/app/core/services/podcast-api.service.ts
+++ b/src/app/core/services/podcast-api.service.ts
@@ -59,7 +59,12 @@ export class PodcastApiService {
     const params = new HttpParams().set('id', itunesId).set('entity', 'podcast');
     return this.http
       .get<{ results: ItunesPodcast[] }>(`${this.itunesBase}/lookup`, { params })
-      .pipe(map((res) => this.mapItunesPodcast(res.results[0])));
+      .pipe(
+        map((res) => {
+          if (!res.results?.length) throw new Error('Podcast not found');
+          return this.mapItunesPodcast(res.results[0]);
+        }),
+      );
   }
 
   /**

--- a/src/app/features/home/home.page.html
+++ b/src/app/features/home/home.page.html
@@ -22,7 +22,7 @@
     @if (store.subscriptions().length > 0) {
       <div class="subscriptions-scroll">
         <div class="subscriptions-row">
-          @for (podcast of store.subscriptions(); track podcast) {
+          @for (podcast of store.subscriptions(); track podcast.id) {
             <wavely-podcast-card
               class="subscription-card"
               [podcast]="podcast"
@@ -71,7 +71,7 @@
 
     @if (!store.isLoading() && !store.error() && store.trending().length > 0) {
       <div class="podcast-grid">
-        @for (podcast of store.trending(); track podcast) {
+        @for (podcast of store.trending(); track podcast.id) {
           <wavely-podcast-card [podcast]="podcast" (cardClick)="navigateToPodcast($event)"></wavely-podcast-card>
         }
       </div>

--- a/src/app/features/library/library.page.html
+++ b/src/app/features/library/library.page.html
@@ -123,7 +123,7 @@
     @if (store.subscriptions().length > 0) {
       <p class="list-hint">Swipe left to unsubscribe</p>
       <ion-list lines="full">
-        @for (podcast of store.subscriptions(); track podcast) {
+        @for (podcast of store.subscriptions(); track podcast.id) {
           <ion-item-sliding #slidingItem>
             <ion-item button detail="true" (click)="navigateToPodcast(podcast)">
               <ion-avatar slot="start" class="podcast-avatar">

--- a/src/app/features/podcast-detail/podcast-detail.page.html
+++ b/src/app/features/podcast-detail/podcast-detail.page.html
@@ -88,7 +88,7 @@
     }
     @if (episodes.length > 0) {
       <ion-list lines="full">
-        @for (episode of episodes; track episode) {
+        @for (episode of episodes; track episode.id) {
           <ion-item
             button
             [attr.aria-label]="'Play ' + episode.title"

--- a/src/app/features/search/search.page.html
+++ b/src/app/features/search/search.page.html
@@ -48,7 +48,7 @@
 
   @if (!store.isLoading() && store.searchResults().length > 0) {
     <div class="podcast-grid">
-      @for (podcast of store.searchResults(); track podcast) {
+      @for (podcast of store.searchResults(); track podcast.id) {
         <wavely-podcast-card [podcast]="podcast" (cardClick)="navigateToPodcast($event)"></wavely-podcast-card>
       }
     </div>


### PR DESCRIPTION
Fast-track bug fixes to production:
- @for track by id (home, library, search, podcast-detail) — prevents full DOM re-render on every signal update
- lookupPodcast empty results guard — prevents runtime crash on unknown podcast IDs