### PR TITLE
chore: promote staging → main

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,6 +7,10 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     ["@semantic-release/npm", { "npmPublish": false }],
+    ["@semantic-release/git", {
+      "assets": ["package.json"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]"
+    }],
     "@semantic-release/github"
   ]
 }

--- a/e2e/src/browse.spec.ts
+++ b/e2e/src/browse.spec.ts
@@ -25,7 +25,7 @@ test.describe('Browse page', () => {
   test.beforeEach(async ({ page }) => {
     await page.route(ITUNES_TOP_PODCASTS_URL, async (route) => {
       const url = new URL(route.request().url());
-      const genreId = url.pathname.match(/genre\/(\d+)/)?.[1] ?? 'all';
+      const genreId = url.pathname.match(/genre=(\d+)/)?.[1] ?? 'all';
 
       const payloadByGenre: Record<string, unknown[]> = {
         all: [

--- a/scripts/generate-env.mjs
+++ b/scripts/generate-env.mjs
@@ -8,6 +8,7 @@
  */
 
 import { writeFileSync, readFileSync } from 'fs';
+import { execSync } from 'child_process';
 
 const target = process.env['ENV_TARGET'] ?? 'all';
 const isStaging = target === 'staging';
@@ -33,7 +34,17 @@ const get = (key) => {
 const getSentryDsn = () => process.env['NG_APP_SENTRY_DSN'] ?? '';
 
 const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
-const appVersion = pkg.version ?? '0.0.0';
+
+// Prefer the latest git tag (set by semantic-release) over package.json version.
+// This ensures the app always shows the correct deployed version even if
+// package.json hasn't been updated in the repo yet.
+let appVersion;
+try {
+  const tag = execSync('git describe --tags --abbrev=0', { encoding: 'utf8' }).trim();
+  appVersion = tag.replace(/^v/, '');
+} catch {
+  appVersion = pkg.version ?? '0.0.0';
+}
 
 if (isProdOrStaging) {
   const missing = REQUIRED_KEYS.filter((key) => !get(key));

--- a/src/app/core/services/podcast-api.service.spec.ts
+++ b/src/app/core/services/podcast-api.service.spec.ts
@@ -215,7 +215,7 @@ describe('PodcastApiService', () => {
       service.getTrendingPodcasts(5, 1310, 'us').subscribe();
 
       const req = httpMock.expectOne(
-        `${ITUNES_BASE}/us/rss/toppodcasts/limit=5/genre/1310/json`
+        `${ITUNES_BASE}/us/rss/toppodcasts/limit=5/genre=1310/json`
       );
       req.flush({ feed: { entry: [] } });
     });

--- a/src/app/core/services/podcast-api.service.ts
+++ b/src/app/core/services/podcast-api.service.ts
@@ -75,7 +75,7 @@ export class PodcastApiService {
    */
   getTrendingPodcasts(limit = 25, genreId?: number, country?: string): Observable<Podcast[]> {
     const countryCode = country ?? this.detectCountry();
-    const genrePath = genreId ? `/genre/${genreId}` : '';
+    const genrePath = genreId ? `/genre=${genreId}` : '';
     const url = `${this.itunesBase}/${countryCode}/rss/toppodcasts/limit=${limit}${genrePath}/json`;
     return this.http
       .get<ItunesRssFeed>(url)

--- a/src/app/features/browse/browse.page.ts
+++ b/src/app/features/browse/browse.page.ts
@@ -46,13 +46,13 @@ export const PODCAST_CATEGORIES: PodcastCategory[] = [
   { id: 1304, name: 'Education', color: '#34A853' },
   { id: 1303, name: 'Comedy', color: '#FBBC04' },
   { id: 1301, name: 'Arts', color: '#9C27B0' },
-  { id: 1307, name: 'Science', color: '#00ACC1' },
+  { id: 1533, name: 'Science', color: '#00ACC1' },
   { id: 1318, name: 'Technology', color: '#FF5722' },
   { id: 1321, name: 'Business', color: '#607D8B' },
   { id: 1309, name: 'TV & Film', color: '#3F51B5' },
   { id: 1310, name: 'Music', color: '#4CAF50' },
-  { id: 1323, name: 'Sports', color: '#FF9800' },
-  { id: 1324, name: 'True Crime', color: '#424242' },
+  { id: 1545, name: 'Sports', color: '#FF9800' },
+  { id: 1488, name: 'True Crime', color: '#424242' },
 ];
 
 const SKELETON_COUNT = 6;

--- a/src/app/features/podcast-detail/podcast-detail.page.html
+++ b/src/app/features/podcast-detail/podcast-detail.page.html
@@ -34,6 +34,10 @@
   @if (podcastError && !isLoading) {
     <div class="state-message">
       <ion-text color="medium"><p>{{ podcastError }}</p></ion-text>
+      <ion-button fill="outline" size="small" (click)="retryLoad()">
+        <ion-icon name="refresh-outline" slot="start"></ion-icon>
+        Retry
+      </ion-button>
     </div>
   }
 
@@ -80,6 +84,10 @@
     @if (episodesError) {
       <div class="state-message">
         <ion-text color="medium"><p>{{ episodesError }}</p></ion-text>
+        <ion-button fill="outline" size="small" (click)="retryLoad()">
+          <ion-icon name="refresh-outline" slot="start"></ion-icon>
+          Retry
+        </ion-button>
       </div>
     }
     <!-- Episodes -->
@@ -106,6 +114,10 @@
           </ion-item>
         }
       </ion-list>
+
+      <ion-infinite-scroll [disabled]="!hasMoreEpisodes" (ionInfinite)="loadMoreEpisodes($event)">
+        <ion-infinite-scroll-content loadingText="Loading more episodes…"></ion-infinite-scroll-content>
+      </ion-infinite-scroll>
     }
     @if (episodes.length === 0 && !episodesError) {
       <div class="state-message">

--- a/src/app/features/podcast-detail/podcast-detail.page.spec.ts
+++ b/src/app/features/podcast-detail/podcast-detail.page.spec.ts
@@ -107,8 +107,17 @@ describe('PodcastDetailPage', () => {
   });
 
   it('sets independent error messages when API calls fail', async () => {
-    mockApi.lookupPodcast.mockReturnValueOnce(throwError(() => new Error('podcast failed')));
-    mockApi.getPodcastEpisodes.mockReturnValueOnce(throwError(() => new Error('episodes failed')));
+    const podcastErr = throwError(() => new Error('podcast failed'));
+    const episodesErr = throwError(() => new Error('episodes failed'));
+    // retry(2) means 3 total attempts — mock all three
+    mockApi.lookupPodcast
+      .mockReturnValueOnce(podcastErr)
+      .mockReturnValueOnce(podcastErr)
+      .mockReturnValueOnce(podcastErr);
+    mockApi.getPodcastEpisodes
+      .mockReturnValueOnce(episodesErr)
+      .mockReturnValueOnce(episodesErr)
+      .mockReturnValueOnce(episodesErr);
 
     await createComponent();
 

--- a/src/app/features/podcast-detail/podcast-detail.page.ts
+++ b/src/app/features/podcast-detail/podcast-detail.page.ts
@@ -16,16 +16,19 @@ import {
   IonNote,
   IonSkeletonText,
   IonText,
+  IonInfiniteScroll,
+  IonInfiniteScrollContent,
+  InfiniteScrollCustomEvent,
 } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
-import { checkmarkCircle, addCircleOutline, playCircleOutline } from 'ionicons/icons';
+import { checkmarkCircle, addCircleOutline, playCircleOutline, refreshOutline } from 'ionicons/icons';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
 import { PodcastsStore } from '../../store/podcasts/podcasts.store';
 import { PlayerStore } from '../../store/player/player.store';
 import { AuthStore } from '../../store/auth/auth.store';
 import { SubscriptionSyncService } from '../../core/services/subscription-sync.service';
 import { Podcast, Episode } from '../../core/models/podcast.model';
-import { catchError, forkJoin, of } from 'rxjs';
+import { catchError, forkJoin, of, retry } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { switchMap } from 'rxjs/operators';
 
@@ -49,7 +52,9 @@ import { switchMap } from 'rxjs/operators';
     IonLabel,
     IonNote,
     IonSkeletonText,
-    IonText
+    IonText,
+    IonInfiniteScroll,
+    IonInfiniteScrollContent,
 ],
 })
 export class PodcastDetailPage {
@@ -63,14 +68,20 @@ export class PodcastDetailPage {
   private readonly syncService = inject(SubscriptionSyncService);
   private readonly cdr = inject(ChangeDetectorRef);
 
+  private static readonly PAGE_SIZE = 15;
+
   protected podcast: Podcast | null = null;
+  // All fetched episodes — the source of truth
+  private allEpisodes: Episode[] = [];
+  // Slice shown in the template — grows as user scrolls
   protected episodes: Episode[] = [];
   protected isLoading = true;
   protected episodesError: string | null = null;
   protected podcastError: string | null = null;
+  protected hasMoreEpisodes = false;
 
   constructor() {
-    addIcons({ checkmarkCircle, addCircleOutline, playCircleOutline });
+    addIcons({ checkmarkCircle, addCircleOutline, playCircleOutline, refreshOutline });
 
     // Stream driven from route params — survives reuse; auto-unsubscribes on destroy
     this.route.paramMap
@@ -79,17 +90,21 @@ export class PodcastDetailPage {
           const id = params.get('id') ?? '';
           this.isLoading = true;
           this.podcast = null;
+          this.allEpisodes = [];
           this.episodes = [];
           this.episodesError = null;
           this.podcastError = null;
+          this.hasMoreEpisodes = false;
           return forkJoin({
             podcast: this.api.lookupPodcast(id).pipe(
+              retry(2),
               catchError(() => {
                 this.podcastError = 'Could not load podcast info.';
                 return of(null);
               }),
             ),
             episodes: this.api.getPodcastEpisodes(id, 50).pipe(
+              retry(2),
               catchError(() => {
                 this.episodesError = 'Could not load episodes.';
                 return of([] as Episode[]);
@@ -101,7 +116,56 @@ export class PodcastDetailPage {
       )
       .subscribe(({ podcast, episodes }) => {
         this.podcast = podcast;
-        this.episodes = episodes;
+        this.allEpisodes = episodes;
+        this.episodes = episodes.slice(0, PodcastDetailPage.PAGE_SIZE);
+        this.hasMoreEpisodes = episodes.length > PodcastDetailPage.PAGE_SIZE;
+        this.isLoading = false;
+        this.cdr.markForCheck();
+      });
+  }
+
+  protected loadMoreEpisodes(event: InfiniteScrollCustomEvent): void {
+    const current = this.episodes.length;
+    const next = this.allEpisodes.slice(current, current + PodcastDetailPage.PAGE_SIZE);
+    this.episodes = [...this.episodes, ...next];
+    this.hasMoreEpisodes = this.episodes.length < this.allEpisodes.length;
+    this.cdr.markForCheck();
+    event.target.complete();
+  }
+
+  protected retryLoad(): void {
+    const id = this.route.snapshot.paramMap.get('id') ?? '';
+    this.isLoading = true;
+    this.podcast = null;
+    this.allEpisodes = [];
+    this.episodes = [];
+    this.episodesError = null;
+    this.podcastError = null;
+    this.hasMoreEpisodes = false;
+    this.cdr.markForCheck();
+
+    forkJoin({
+      podcast: this.api.lookupPodcast(id).pipe(
+        retry(2),
+        catchError(() => {
+          this.podcastError = 'Could not load podcast info.';
+          return of(null);
+        }),
+      ),
+      episodes: this.api.getPodcastEpisodes(id, 50).pipe(
+        retry(2),
+        catchError(() => {
+          this.episodesError = 'Could not load episodes.';
+          return of([] as Episode[]);
+        }),
+      ),
+    })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(({ podcast, episodes }) => {
+        this.podcast = podcast;
+        this.allEpisodes = episodes;
+        this.episodes = episodes.slice(0, PodcastDetailPage.PAGE_SIZE);
+        this.hasMoreEpisodes = episodes.length > PodcastDetailPage.PAGE_SIZE;
         this.isLoading = false;
         this.cdr.markForCheck();
       });
@@ -131,9 +195,9 @@ export class PodcastDetailPage {
   protected playEpisode(episode: Episode): void {
     if (!this.podcast) return;
     const podcastTitle = this.podcast.title;
-    // Set the clicked episode as current, queue the rest that follow it
-    const idx = this.episodes.findIndex((e) => e.id === episode.id);
-    const upcoming = this.episodes.slice(idx + 1);
+    // Queue from allEpisodes so episodes not yet loaded in the infinite scroll are included
+    const idx = this.allEpisodes.findIndex((e) => e.id === episode.id);
+    const upcoming = this.allEpisodes.slice(idx + 1);
     this.playerStore.clearQueue();
     upcoming.forEach((e) => this.playerStore.addToQueue({ ...e, podcastTitle }));
     this.playerStore.play({ ...episode, podcastTitle });

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -107,6 +107,16 @@
   box-sizing: border-box;
 }
 
+// Prevent the browser from adding its own scrollbar — Ionic handles scrolling
+// inside ion-content. Without this, desktop browsers show a native scrollbar
+// alongside Ionic's internal scroll, creating an ugly double-scrollbar effect.
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+  background: var(--wavely-background);
+}
+
 ion-content {
   --background: var(--wavely-background);
 }
@@ -121,15 +131,6 @@ ion-toolbar {
 }
 
 /* ─── Desktop / wide-screen responsive ─── */
-
-// Constrain app frame on very large monitors (≥1440px)
-@media (min-width: 1440px) {
-  ion-app {
-    max-width: 1440px;
-    margin: 0 auto;
-    box-shadow: 0 0 60px rgba(0, 0, 0, 0.08);
-  }
-}
 
 // Tablet and desktop: responsive podcast grids + generous padding
 @media (min-width: 768px) {


### PR DESCRIPTION
## Bug Fixes shipping to production

- **Category filter**: iTunes RSS URL fix (`/genre=1303` not `/genre/1303`) — categories now show correct podcasts
- **Genre IDs corrected**: Science (1533), Sports (1545), True Crime (1488)
- **Desktop scrollbar**: `overflow: hidden` on html/body eliminates browser scrollbar
- **Max-width removed**: Content fills the screen instead of shrinking to 1440px strip
- **Podcast detail reliability**: `retry(2)` on API calls + Retry button + infinite scroll (15 eps/page)
- **Version display**: `generate-env.mjs` reads `git describe` for accurate version
- **E2E**: Browse spec regex updated to match new genre URL format

Closes #148 #149