### PR TITLE
fix(e2e): backport browse spec genre regex fix

### DIFF
--- a/e2e/src/browse.spec.ts
+++ b/e2e/src/browse.spec.ts
@@ -25,7 +25,7 @@ test.describe('Browse page', () => {
   test.beforeEach(async ({ page }) => {
     await page.route(ITUNES_TOP_PODCASTS_URL, async (route) => {
       const url = new URL(route.request().url());
-      const genreId = url.pathname.match(/genre\/(\d+)/)?.[1] ?? 'all';
+      const genreId = url.pathname.match(/genre=(\d+)/)?.[1] ?? 'all';
 
       const payloadByGenre: Record<string, unknown[]> = {
         all: [


### PR DESCRIPTION
Backports the E2E browse spec fix from main: regex updated from `/genre/(\d+)/` to `/genre=(\d+)/` to match the corrected iTunes RSS URL format.