### PR TITLE
fix(podcast-detail): increase episode fetch limit 50→200

### DIFF
--- a/src/app/core/services/podcast-api.service.ts
+++ b/src/app/core/services/podcast-api.service.ts
@@ -106,7 +106,7 @@ export class PodcastApiService {
    * Fetch episodes for a podcast via iTunes lookup.
    * Returns up to `limit` most recent episodes.
    */
-  getPodcastEpisodes(itunesId: string, limit = 50): Observable<Episode[]> {
+  getPodcastEpisodes(itunesId: string, limit = 200): Observable<Episode[]> {
     const params = new HttpParams()
       .set('id', itunesId)
       .set('entity', 'podcastEpisode')

--- a/src/app/features/podcast-detail/podcast-detail.page.spec.ts
+++ b/src/app/features/podcast-detail/podcast-detail.page.spec.ts
@@ -101,7 +101,7 @@ describe('PodcastDetailPage', () => {
 
     expect(component).toBeTruthy();
     expect(mockApi.lookupPodcast).toHaveBeenCalledWith('pod-1');
-    expect(mockApi.getPodcastEpisodes).toHaveBeenCalledWith('pod-1', 50);
+    expect(mockApi.getPodcastEpisodes).toHaveBeenCalledWith('pod-1', 200);
     expect(component['podcast']?.id).toBe('pod-1');
     expect(component['episodes']).toHaveLength(2);
   });

--- a/src/app/features/podcast-detail/podcast-detail.page.ts
+++ b/src/app/features/podcast-detail/podcast-detail.page.ts
@@ -103,7 +103,7 @@ export class PodcastDetailPage {
                 return of(null);
               }),
             ),
-            episodes: this.api.getPodcastEpisodes(id, 50).pipe(
+            episodes: this.api.getPodcastEpisodes(id, 200).pipe(
               retry(2),
               catchError(() => {
                 this.episodesError = 'Could not load episodes.';
@@ -152,7 +152,7 @@ export class PodcastDetailPage {
           return of(null);
         }),
       ),
-      episodes: this.api.getPodcastEpisodes(id, 50).pipe(
+      episodes: this.api.getPodcastEpisodes(id, 200).pipe(
         retry(2),
         catchError(() => {
           this.episodesError = 'Could not load episodes.';


### PR DESCRIPTION
## Root Cause

The iTunes `/lookup?entity=podcastEpisode&limit=N` response always includes the podcast record itself in the result set. With `limit=50`, only **49 episodes** were ever returned. Infinite scroll would exhaust the set after 3 pages (45 items shown), with a tiny 4-item last page, then stop — giving the impression that ~40 episodes was the podcast's full library.

## Fix

Bump limit to 200 (iTunes API maximum). This yields up to **199 episodes** per request.

For podcasts with 200+ episodes this is still a hard ceiling — real pagination would require RSS feed parsing — but it's a massive UX improvement over 49.

## Changes
- `podcast-api.service.ts`: default parameter `limit = 50` → `limit = 200`
- `podcast-detail.page.ts`: both call sites (constructor + retryLoad) `50` → `200`
- `podcast-detail.page.spec.ts`: assertion updated to match