### PR TITLE
chore(release): promote country-selector to main (v1.2.x)

### DIFF
--- a/src/app/core/services/country.service.spec.ts
+++ b/src/app/core/services/country.service.spec.ts
@@ -1,0 +1,88 @@
+import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { PodcastApiService } from './podcast-api.service';
+import { CountryService } from './country.service';
+
+describe('CountryService', () => {
+  let getItemSpy: jest.SpyInstance;
+  let setItemSpy: jest.SpyInstance;
+
+  function setup(platformId: string, savedCountry: string | null, detectedCountry = 'es') {
+    getItemSpy = jest
+      .spyOn(Storage.prototype, 'getItem')
+      .mockImplementation((key) => (key === 'wavely:country' ? savedCountry : null));
+    setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: PLATFORM_ID, useValue: platformId },
+        {
+          provide: PodcastApiService,
+          useValue: { detectCountry: jest.fn().mockReturnValue(detectedCountry) },
+        },
+      ],
+    });
+
+    return TestBed.inject(CountryService);
+  }
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    jest.restoreAllMocks();
+  });
+
+  describe('initialization', () => {
+    it('uses saved localStorage value on browser', () => {
+      const svc = setup('browser', 'gb');
+      expect(svc.country()).toBe('gb');
+      expect(getItemSpy).toHaveBeenCalledWith('wavely:country');
+    });
+
+    it('falls back to detectCountry when nothing is saved', () => {
+      const svc = setup('browser', null);
+      expect(svc.country()).toBe('es');
+    });
+
+    it('falls back to detectCountry in SSR without touching localStorage', () => {
+      const svc = setup('server', null);
+      expect(svc.country()).toBe('es');
+      expect(getItemSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setCountry', () => {
+    it('updates the signal', () => {
+      const svc = setup('browser', null);
+      svc.setCountry('de');
+      expect(svc.country()).toBe('de');
+    });
+
+    it('persists to localStorage on browser', () => {
+      const svc = setup('browser', null);
+      svc.setCountry('de');
+      expect(setItemSpy).toHaveBeenCalledWith('wavely:country', 'de');
+    });
+
+    it('does not call localStorage in SSR', () => {
+      const svc = setup('server', null);
+      svc.setCountry('de');
+      expect(setItemSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getFlag', () => {
+    it('returns correct emoji flag for valid 2-letter codes', () => {
+      const svc = setup('browser', null);
+      expect(svc.getFlag('us')).toBe('🇺🇸');
+      expect(svc.getFlag('gb')).toBe('🇬🇧');
+      expect(svc.getFlag('de')).toBe('🇩🇪');
+    });
+
+    it('returns 🌍 for invalid or unknown codes', () => {
+      const svc = setup('browser', null);
+      expect(svc.getFlag('xyz')).toBe('🌍');
+      expect(svc.getFlag('')).toBe('🌍');
+    });
+  });
+});

--- a/src/app/core/services/country.service.ts
+++ b/src/app/core/services/country.service.ts
@@ -1,0 +1,82 @@
+import { Injectable, PLATFORM_ID, inject, signal } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
+import { PodcastApiService } from './podcast-api.service';
+
+export interface PodcastMarket {
+  code: string;
+  name: string;
+}
+
+export const PODCAST_MARKETS: PodcastMarket[] = [
+  { code: 'us', name: 'United States' },
+  { code: 'gb', name: 'United Kingdom' },
+  { code: 'au', name: 'Australia' },
+  { code: 'ca', name: 'Canada' },
+  { code: 'ie', name: 'Ireland' },
+  { code: 'nz', name: 'New Zealand' },
+  { code: 'za', name: 'South Africa' },
+  { code: 'es', name: 'Spain' },
+  { code: 'mx', name: 'Mexico' },
+  { code: 'ar', name: 'Argentina' },
+  { code: 'cl', name: 'Chile' },
+  { code: 'co', name: 'Colombia' },
+  { code: 'fr', name: 'France' },
+  { code: 'be', name: 'Belgium' },
+  { code: 'de', name: 'Germany' },
+  { code: 'at', name: 'Austria' },
+  { code: 'ch', name: 'Switzerland' },
+  { code: 'it', name: 'Italy' },
+  { code: 'br', name: 'Brazil' },
+  { code: 'pt', name: 'Portugal' },
+  { code: 'jp', name: 'Japan' },
+  { code: 'kr', name: 'South Korea' },
+  { code: 'cn', name: 'China' },
+  { code: 'in', name: 'India' },
+  { code: 'nl', name: 'Netherlands' },
+  { code: 'se', name: 'Sweden' },
+  { code: 'no', name: 'Norway' },
+  { code: 'dk', name: 'Denmark' },
+  { code: 'fi', name: 'Finland' },
+  { code: 'pl', name: 'Poland' },
+  { code: 'ru', name: 'Russia' },
+  { code: 'tr', name: 'Turkey' },
+];
+
+@Injectable({ providedIn: 'root' })
+export class CountryService {
+  private static readonly STORAGE_KEY = 'wavely:country';
+
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly api = inject(PodcastApiService);
+
+  readonly country = signal<string>(this.initCountry());
+
+  private initCountry(): string {
+    if (isPlatformBrowser(this.platformId)) {
+      const saved = localStorage.getItem(CountryService.STORAGE_KEY);
+      if (saved) {
+        const normalized = saved.toLowerCase();
+        if (/^[a-z]{2}$/.test(normalized)) return normalized;
+      }
+    }
+    return this.api.detectCountry();
+  }
+
+  setCountry(code: string): void {
+    const normalized = code.toLowerCase();
+    if (!/^[a-z]{2}$/.test(normalized)) return;
+    this.country.set(normalized);
+    if (isPlatformBrowser(this.platformId)) {
+      localStorage.setItem(CountryService.STORAGE_KEY, normalized);
+    }
+  }
+
+  getFlag(code: string): string {
+    if (!/^[a-z]{2}$/.test(code)) return '🌍';
+    return code
+      .split('')
+      .map((c) => String.fromCodePoint(c.charCodeAt(0) - 97 + 0x1f1e6))
+      .join('');
+  }
+}

--- a/src/app/features/browse/browse.page.html
+++ b/src/app/features/browse/browse.page.html
@@ -4,14 +4,9 @@
     <ion-buttons slot="end">
       <ion-button
         class="country-toggle"
-        [class.country-toggle--global]="globalBrowse"
-        (click)="toggleGlobalBrowse()"
-        [attr.aria-label]="globalBrowse ? 'Showing global content, tap for local' : 'Showing local content, tap for global'">
-        @if (globalBrowse) {
-          <span class="country-toggle__flag">🌍</span>
-        } @else {
-          <span class="country-toggle__flag">{{ countryFlag }}</span>
-        }
+        [attr.aria-label]="'Browsing ' + currentMarketName + ' content, tap to change'"
+        (click)="presentCountryPicker()">
+        <span class="country-toggle__flag">{{ countryService.getFlag(countryService.country()) }}</span>
       </ion-button>
     </ion-buttons>
   </ion-toolbar>

--- a/src/app/features/browse/browse.page.spec.ts
+++ b/src/app/features/browse/browse.page.spec.ts
@@ -1,10 +1,12 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
+import { ActionSheetController } from '@ionic/angular/standalone';
 import { of } from 'rxjs';
 
 import { BrowsePage, PODCAST_CATEGORIES } from './browse.page';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
+import { CountryService } from '../../core/services/country.service';
 import { mockPodcast } from '../../../testing/podcast-fixtures';
 
 describe('BrowsePage', () => {
@@ -18,6 +20,14 @@ describe('BrowsePage', () => {
     detectCountry: jest.fn(() => 'us'),
   };
   const mockRouter = { navigate: jest.fn() };
+  const mockCountryService = {
+    country: signal('us'),
+    setCountry: jest.fn(),
+    getFlag: jest.fn(() => '🇺🇸'),
+  };
+  const mockActionSheetCtrl = {
+    create: jest.fn().mockResolvedValue({ present: jest.fn() }),
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -25,6 +35,8 @@ describe('BrowsePage', () => {
       providers: [
         { provide: PodcastApiService, useValue: mockApi },
         { provide: Router, useValue: mockRouter },
+        { provide: CountryService, useValue: mockCountryService },
+        { provide: ActionSheetController, useValue: mockActionSheetCtrl },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     })
@@ -79,5 +91,25 @@ describe('BrowsePage', () => {
     (component as any).navigateToPodcast(mockPodcast({ id: 'pod-9' }));
 
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/podcast', 'pod-9']);
+  });
+
+  it('presentCountryPicker opens action sheet and sets country on selection', async () => {
+    const mockPresent = jest.fn().mockResolvedValue(undefined);
+    let capturedHandler: (() => void) | undefined;
+
+    mockActionSheetCtrl.create.mockImplementationOnce(async (opts: { buttons: { handler?: () => void; role?: string; text?: string }[] }) => {
+      capturedHandler = opts.buttons.find((b) => b.text?.includes('United States'))?.handler;
+      return { present: mockPresent };
+    });
+
+    await (component as any).presentCountryPicker();
+
+    expect(mockActionSheetCtrl.create).toHaveBeenCalledWith(
+      expect.objectContaining({ header: 'Browse by Country' })
+    );
+    expect(mockPresent).toHaveBeenCalled();
+
+    capturedHandler?.();
+    expect(mockCountryService.setCountry).toHaveBeenCalledWith('us');
   });
 });

--- a/src/app/features/browse/browse.page.ts
+++ b/src/app/features/browse/browse.page.ts
@@ -20,6 +20,7 @@ import {
   IonText,
   IonButtons,
   IonButton,
+  ActionSheetController,
 } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { alertCircleOutline, refreshOutline, searchOutline } from 'ionicons/icons';
@@ -28,6 +29,7 @@ import { PodcastCardComponent } from '../../shared/components/podcast-card/podca
 import { PodcastApiService } from '../../core/services/podcast-api.service';
 import { Podcast } from '../../core/models/podcast.model';
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
+import { CountryService, PODCAST_MARKETS } from '../../core/services/country.service';
 
 // Genre IDs used to populate the three Browse sections with distinct content.
 // Featured → News, New & Noteworthy → Technology, Top → overall chart.
@@ -84,11 +86,12 @@ const CHIP_SKELETON_COUNT = 6;
 export class BrowsePage implements OnDestroy {
   private readonly api = inject(PodcastApiService);
   private readonly router = inject(Router);
+  protected readonly countryService = inject(CountryService);
+  private readonly actionSheetCtrl = inject(ActionSheetController);
 
   protected readonly categories = PODCAST_CATEGORIES;
   protected readonly skeletons = Array.from({ length: SKELETON_COUNT });
   protected readonly chipSkeletons = Array.from({ length: CHIP_SKELETON_COUNT });
-  protected readonly detectedCountry: string;
 
   protected selectedCategory = signal(PODCAST_CATEGORIES[0]);
   protected topPodcasts = signal<Podcast[]>([]);
@@ -96,13 +99,11 @@ export class BrowsePage implements OnDestroy {
   protected newNoteworthyPodcasts = signal<Podcast[]>([]);
   protected isLoading = signal(false);
   protected error = signal<string | null>(null);
-  protected globalBrowse = false;
 
   private readonly category$ = new Subject<PodcastCategory>();
   private readonly destroy$ = new Subject<void>();
 
   constructor() {
-    this.detectedCountry = this.api.detectCountry();
     addIcons({ searchOutline, alertCircleOutline, refreshOutline });
 
     this.category$
@@ -115,7 +116,7 @@ export class BrowsePage implements OnDestroy {
           this.newNoteworthyPodcasts.set([]);
         }),
         switchMap(() => {
-          const country = this.globalBrowse ? 'us' : this.detectedCountry;
+          const country = this.countryService.country();
           return forkJoin({
             topPodcasts: this.api.getTrendingPodcasts(25, undefined, country),
             featuredPodcasts: this.api.getTrendingPodcasts(5, FEATURED_GENRE_ID, country),
@@ -162,9 +163,23 @@ export class BrowsePage implements OnDestroy {
     this.router.navigate(['/browse/category', category.id]);
   }
 
-  protected toggleGlobalBrowse(): void {
-    this.globalBrowse = !this.globalBrowse;
-    this.category$.next(this.selectedCategory());
+  protected async presentCountryPicker(): Promise<void> {
+    const currentCode = this.countryService.country();
+    const actionSheet = await this.actionSheetCtrl.create({
+      header: 'Browse by Country',
+      buttons: [
+        ...PODCAST_MARKETS.map((m) => ({
+          text: `${this.countryService.getFlag(m.code)} ${m.name}`,
+          cssClass: m.code === currentCode ? 'country-active' : '',
+          handler: () => {
+            this.countryService.setCountry(m.code);
+            this.category$.next(this.selectedCategory());
+          },
+        })),
+        { text: 'Cancel', role: 'cancel' },
+      ],
+    });
+    await actionSheet.present();
   }
 
   protected retryCurrentCategory(): void {
@@ -179,9 +194,8 @@ export class BrowsePage implements OnDestroy {
     this.router.navigate(['/podcast', podcast.id]);
   }
 
-  protected get countryFlag(): string {
-    const code = this.detectedCountry;
-    if (!/^[a-z]{2}$/.test(code)) return '🌍';
-    return code.split('').map((c) => String.fromCodePoint(c.charCodeAt(0) - 97 + 0x1f1e6)).join('');
+  protected get currentMarketName(): string {
+    const code = this.countryService.country();
+    return PODCAST_MARKETS.find((m) => m.code === code)?.name ?? code.toUpperCase();
   }
 }

--- a/src/app/features/browse/category-detail/category-detail.page.spec.ts
+++ b/src/app/features/browse/category-detail/category-detail.page.spec.ts
@@ -1,10 +1,11 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { BehaviorSubject, of } from 'rxjs';
 
 import { CategoryDetailPage } from './category-detail.page';
 import { PodcastApiService } from '../../../core/services/podcast-api.service';
+import { CountryService } from '../../../core/services/country.service';
 import { mockPodcast } from '../../../../testing/podcast-fixtures';
 
 describe('CategoryDetailPage', () => {
@@ -28,6 +29,12 @@ describe('CategoryDetailPage', () => {
     navigate: jest.fn(),
   };
 
+  const mockCountryService = {
+    country: signal('us'),
+    setCountry: jest.fn(),
+    getFlag: jest.fn(() => '🇺🇸'),
+  };
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [CategoryDetailPage],
@@ -40,6 +47,7 @@ describe('CategoryDetailPage', () => {
         },
         { provide: PodcastApiService, useValue: mockApi },
         { provide: Router, useValue: mockRouter },
+        { provide: CountryService, useValue: mockCountryService },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     })

--- a/src/app/features/browse/category-detail/category-detail.page.ts
+++ b/src/app/features/browse/category-detail/category-detail.page.ts
@@ -26,6 +26,7 @@ import { catchError, of, switchMap, tap } from 'rxjs';
 
 import { Podcast } from '../../../core/models/podcast.model';
 import { PodcastApiService } from '../../../core/services/podcast-api.service';
+import { CountryService } from '../../../core/services/country.service';
 import { EmptyStateComponent } from '../../../shared/components/empty-state/empty-state.component';
 import { PodcastCardComponent } from '../../../shared/components/podcast-card/podcast-card.component';
 import { PODCAST_CATEGORIES } from '../browse.page';
@@ -59,8 +60,7 @@ export class CategoryDetailPage {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
-
-  private readonly country: string;
+  private readonly countryService = inject(CountryService);
 
   protected readonly skeletons = Array.from({ length: SKELETON_COUNT });
 
@@ -79,7 +79,6 @@ export class CategoryDetailPage {
   );
 
   constructor() {
-    this.country = this.api.detectCountry();
     addIcons({ searchOutline, alertCircleOutline, refreshOutline });
 
     this.route.paramMap
@@ -106,7 +105,7 @@ export class CategoryDetailPage {
               'Category'
           );
 
-          return this.api.getTrendingPodcasts(50, rawGenreId, this.country).pipe(
+          return this.api.getTrendingPodcasts(50, rawGenreId, this.countryService.country()).pipe(
             catchError(() => {
               this.error.set('Could not load this category. Please try again.');
               return of([] as Podcast[]);
@@ -138,7 +137,7 @@ export class CategoryDetailPage {
     this.isLoading.set(true);
     this.error.set(null);
     this.api
-      .getTrendingPodcasts(50, currentGenreId, this.country)
+      .getTrendingPodcasts(50, currentGenreId, this.countryService.country())
       .pipe(
         catchError(() => {
           this.error.set('Could not load this category. Please try again.');

--- a/src/app/features/home/home.page.spec.ts
+++ b/src/app/features/home/home.page.spec.ts
@@ -6,6 +6,7 @@ import { of } from 'rxjs';
 import { HomePage } from './home.page';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
 import { PodcastsStore } from '../../store/podcasts/podcasts.store';
+import { CountryService } from '../../core/services/country.service';
 import { mockPodcast } from '../../../testing/podcast-fixtures';
 
 describe('HomePage', () => {
@@ -23,6 +24,11 @@ describe('HomePage', () => {
     setError: jest.fn(),
   };
   const mockRouter = { navigate: jest.fn() };
+  const mockCountryService = {
+    country: signal('us'),
+    setCountry: jest.fn(),
+    getFlag: jest.fn(() => '🇺🇸'),
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -31,6 +37,7 @@ describe('HomePage', () => {
         { provide: PodcastApiService, useValue: mockApi },
         { provide: PodcastsStore, useValue: mockStore },
         { provide: Router, useValue: mockRouter },
+        { provide: CountryService, useValue: mockCountryService },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     })

--- a/src/app/features/home/home.page.ts
+++ b/src/app/features/home/home.page.ts
@@ -26,6 +26,7 @@ import {
 } from 'ionicons/icons';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
 import { PodcastsStore } from '../../store/podcasts/podcasts.store';
+import { CountryService } from '../../core/services/country.service';
 import { PodcastCardComponent } from '../../shared/components/podcast-card/podcast-card.component';
 import { Podcast } from '../../core/models/podcast.model';
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
@@ -57,8 +58,7 @@ export class HomePage implements OnInit {
   private readonly api = inject(PodcastApiService);
   protected readonly store = inject(PodcastsStore);
   private readonly router = inject(Router);
-
-  private readonly country: string;
+  private readonly countryService = inject(CountryService);
 
   protected readonly skeletons = Array.from({ length: SKELETON_COUNT });
 
@@ -73,7 +73,6 @@ export class HomePage implements OnInit {
   };
 
   constructor() {
-    this.country = this.api.detectCountry();
     addIcons({
       searchOutline,
       refreshOutline,
@@ -113,7 +112,7 @@ export class HomePage implements OnInit {
   private loadTrending(): Promise<void> {
     this.store.setLoading(true);
     return new Promise((resolve) => {
-      this.api.getTrendingPodcasts(25, undefined, this.country).subscribe({
+      this.api.getTrendingPodcasts(25, undefined, this.countryService.country()).subscribe({
         next: (podcasts) => {
           this.store.setTrending(podcasts);
           this.store.setLoading(false);


### PR DESCRIPTION
Promotes country-selector feature from staging → main for production deployment.

**Feature: Persistent country selector (#150)**
- New `CountryService` — country `Signal<string>`, persisted in `localStorage['wavely:country']` with validation/normalization
- 32 supported iTunes markets
- Browse page: action sheet country picker (replaces binary toggle)
- Fix: `CategoryDetailPage` and `HomePage` now respect the user's country selection (previously always ignored it)
- Accessible aria-label uses human-readable country name
- 257 unit tests passing ✅ | E2E: pass ✅