### PR TITLE
fix(ci): generate env stubs before E2E build

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Generate environment stubs
+        run: node scripts/generate-env.mjs
+
       - name: Build for E2E
         # Uses environment.e2e.ts: fake Firebase config + useEmulators=true
         run: |


### PR DESCRIPTION
E2E build uses `configuration=e2e` which replaces environment files, but TypeScript still needs stub files to exist during compilation. Adds `node scripts/generate-env.mjs` step before build in `e2e.yml`.