### PR TITLE
chore(release): bump version to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavely/source",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",

--- a/src/environments/environment.e2e.ts
+++ b/src/environments/environment.e2e.ts
@@ -3,7 +3,7 @@
 // Never deployed to production.
 export const environment = {
   production: false,
-  appVersion: '1.2.1-e2e',
+  appVersion: '1.3.0-e2e',
   useEmulators: true,
   sentryDsn: '',
   firebase: {


### PR DESCRIPTION
Bumps package.json version from 1.2.1 → 1.3.0 to reflect new features since last production release.

## Changes
- `package.json`: version 1.2.1 → 1.3.0
- `src/environments/environment.e2e.ts`: appVersion 1.2.1-e2e → 1.3.0-e2e

## Why 1.3.0?
The `feat(browse): persistent country selector` commit since v1.2.1 tag warrants a minor bump per semver.