### PR TITLE
chore(release): promote v1.3.0 to staging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@wavely/source",
-  "version": "1.2.1",
+
+
+  "version": "1.3.0",
+
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",

--- a/src/environments/environment.e2e.ts
+++ b/src/environments/environment.e2e.ts
@@ -3,7 +3,10 @@
 // Never deployed to production.
 export const environment = {
   production: false,
-  appVersion: '1.2.1-e2e',
+
+
+  appVersion: '1.3.0-e2e',
+
   useEmulators: true,
   sentryDsn: '',
   firebase: {


### PR DESCRIPTION
Promotes v1.3.0 from dev to staging for E2E validation.

Version conflicts in `package.json` and `environment.e2e.ts` resolved (keeping 1.3.0 from dev).