### PR TITLE
chore(release): v1.3.0 production deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@wavely/source",
-  "version": "1.2.1",
+
+
+  "version": "1.3.0",
+
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",

--- a/src/environments/environment.e2e.ts
+++ b/src/environments/environment.e2e.ts
@@ -3,7 +3,10 @@
 // Never deployed to production.
 export const environment = {
   production: false,
-  appVersion: '1.2.1-e2e',
+
+
+  appVersion: '1.3.0-e2e',
+
   useEmulators: true,
   sentryDsn: '',
   firebase: {


### PR DESCRIPTION
Promotes v1.3.0 to production.

### What's in 1.3.0
- 🌍 Persistent country selector (iTunes market per region)
- 📻 Episode fetch limit 50 → 200
- 🔧 CI env stub generation fixed across all workflows
- 🔢 Version aligned to 1.3.0

All CI gates passed on staging ✅