### PR TITLE
fix(ci): remove @semantic-release/git and npm plugins

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,11 +6,6 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/npm", { "npmPublish": false }],
-    ["@semantic-release/git", {
-      "assets": ["package.json"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]"
-    }],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
Fixes the production deploy failure caused by `@semantic-release/git` trying to push `package.json` directly to the protected `main` branch.

**Root cause:** `@semantic-release/git` commits and pushes version changes back to main, which is blocked by branch protection.

**Fix:** Remove `@semantic-release/git` and `@semantic-release/npm` plugins. Versions are managed manually via PRs. Only keep:
- `commit-analyzer` — determines next version
- `release-notes-generator` — generates changelog
- `github` — creates GitHub releases and tags

This was fixed before in #104 but got reintroduced.