### PR TITLE
chore: promote dev → staging (v1.3.2 RSS review fixes)

### DIFF
--- a/src/app/core/services/podcast-api.service.spec.ts
+++ b/src/app/core/services/podcast-api.service.spec.ts
@@ -321,7 +321,7 @@ describe('PodcastApiService', () => {
   describe('getEpisodesFromRss()', () => {
     const FEED_URL = 'https://example.com/feed.xml';
     const PODCAST_ID = 'pod-1';
-    const PROXY_URL = `https://corsproxy.io/?${FEED_URL}`;
+    const PROXY_URL = `https://corsproxy.io/?${encodeURIComponent(FEED_URL)}`;
 
     const rssXml = (items: string) => `<?xml version="1.0" encoding="UTF-8"?>
 <rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
@@ -435,6 +435,31 @@ describe('PodcastApiService', () => {
       httpMock.expectOne((r) => r.url === FEED_URL).flush(rssXml(audioItem(1)));
 
       expect(result[0].podcastId).toBe(PODCAST_ID);
+    });
+
+    it('uses safe ISO fallback when pubDate is missing or unparseable', () => {
+      const badDateItems = `
+<item>
+  <title>No Date</title>
+  <enclosure url="https://example.com/ep-nodate.mp3" type="audio/mpeg" length="1234"/>
+  <guid>guid-nodate</guid>
+</item>
+<item>
+  <title>Bad Date</title>
+  <pubDate>not-a-real-date</pubDate>
+  <enclosure url="https://example.com/ep-baddate.mp3" type="audio/mpeg" length="1234"/>
+  <guid>guid-baddate</guid>
+</item>`;
+
+      let result: { releaseDate: string }[] = [];
+      service.getEpisodesFromRss(FEED_URL, PODCAST_ID).subscribe((eps) => (result = eps));
+      httpMock.expectOne((r) => r.url === FEED_URL).flush(rssXml(badDateItems));
+
+      // Both should produce a valid ISO timestamp, never "Invalid Date"
+      expect(result).toHaveLength(2);
+      result.forEach((ep) => {
+        expect(new Date(ep.releaseDate).toISOString()).toBe(ep.releaseDate);
+      });
     });
   });
 });

--- a/src/app/core/services/podcast-api.service.ts
+++ b/src/app/core/services/podcast-api.service.ts
@@ -18,6 +18,9 @@ export class PodcastApiService {
   private readonly http = inject(HttpClient);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly itunesBase = 'https://itunes.apple.com';
+  // CORS proxy used when a feed blocks cross-origin browser requests.
+  // To use a different proxy, subclass PodcastApiService and override this property.
+  private readonly corsProxyUrl = 'https://corsproxy.io/?';
 
   /**
    * Detect the user's country from the browser locale.
@@ -136,7 +139,7 @@ export class PodcastApiService {
 
     return this.http.get(feedUrl, { responseType: 'text' }).pipe(
       catchError(() =>
-        this.http.get(`https://corsproxy.io/?${feedUrl}`, { responseType: 'text' }),
+        this.http.get(`${this.corsProxyUrl}${encodeURIComponent(feedUrl)}`, { responseType: 'text' }),
       ),
       map(parse),
       catchError(() => of([] as Episode[])),
@@ -174,7 +177,7 @@ export class PodcastApiService {
           audioUrl: enclosure.getAttribute('url') ?? '',
           imageUrl: imageHref,
           duration: this.parseDuration(duration),
-          releaseDate: pubDate ? new Date(pubDate).toISOString() : new Date().toISOString(),
+          releaseDate: this.parsePubDate(pubDate),
         };
       });
   }
@@ -203,6 +206,13 @@ export class PodcastApiService {
     if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
     if (parts.length === 2) return parts[0] * 60 + parts[1];
     return Math.round(Number(raw)) || 0;
+  }
+
+  /** Parses a RFC-2822 pubDate string; returns a safe ISO fallback on invalid input. */
+  private parsePubDate(raw: string): string {
+    if (!raw) return new Date().toISOString();
+    const d = new Date(raw);
+    return isNaN(d.getTime()) ? new Date().toISOString() : d.toISOString();
   }
 
   private mapItunesPodcast(raw: ItunesPodcast): Podcast {

--- a/src/app/features/episode-detail/episode-detail.page.ts
+++ b/src/app/features/episode-detail/episode-detail.page.ts
@@ -128,12 +128,34 @@ export class EpisodeDetailPage {
               ),
             }).pipe(
               switchMap(({ episodes, podcast }) => {
+                // iTunes episodes use trackId-based IDs; RSS episodes use GUID-based IDs.
+                // If found via iTunes, use it directly.
                 const ep = episodes.find((e) => e.id === episodeId) ?? null;
-                if (!ep) this.error.set('Episode not found.');
-                this.episode.set(ep);
-                this.podcast.set(podcast);
-                this.isLoading.set(false);
-                return of(null);
+                if (ep) {
+                  this.episode.set(ep);
+                  this.podcast.set(podcast);
+                  this.isLoading.set(false);
+                  return of(null);
+                }
+
+                // Not in iTunes index — try RSS so deep links to older/RSS-sourced
+                // episodes (whose IDs are GUID-derived) still resolve.
+                if (!podcast?.feedUrl) {
+                  this.error.set('Episode not found.');
+                  this.isLoading.set(false);
+                  return of(null);
+                }
+
+                return this.api.getEpisodesFromRss(podcast.feedUrl, podcastId).pipe(
+                  switchMap((rssEpisodes) => {
+                    const rssEp = rssEpisodes.find((e) => e.id === episodeId) ?? null;
+                    if (!rssEp) this.error.set('Episode not found.');
+                    this.episode.set(rssEp);
+                    this.podcast.set(podcast);
+                    this.isLoading.set(false);
+                    return of(null);
+                  }),
+                );
               }),
             );
           }


### PR DESCRIPTION
## Changes\n- fix(podcast): encode feedUrl with encodeURIComponent in CORS proxy call\n- fix(podcast): safe pubDate parsing with NaN guard (parsePubDate helper)\n- fix(podcast): corsProxyUrl named constant with accurate comment\n- fix(podcast): EpisodeDetailPage Strategy 3 RSS fallback for GUID-based episode IDs\n\n## Version\n1.3.2 — no version change needed, staging already at 1.3.2\n\n## CI Gate\n- Unit tests\n- E2E Playwright