### PR TITLE
release: v1.3.3 — country-aware iTunes lookups

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,6 +75,10 @@ jobs:
           USE_EMULATORS: 'true'
           FIREBASE_AUTH_EMULATOR_HOST: '127.0.0.1:9099'
           BASE_URL: 'http://localhost:4200'
+          # Note: real QA credentials (WAVELY_QA_EMAIL / WAVELY_QA_PASSWORD) are intentionally
+          # NOT exposed here — this job uses the Firebase Auth Emulator and never contacts
+          # production auth. They will be wired in a dedicated e2e-staging.yml smoke-test
+          # workflow that runs post-deploy against the staging Firebase project.
 
       - name: Upload Playwright report
         if: always()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavely/source",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",

--- a/src/app/core/services/podcast-api.service.spec.ts
+++ b/src/app/core/services/podcast-api.service.spec.ts
@@ -132,6 +132,59 @@ describe('PodcastApiService', () => {
     });
   });
 
+  describe('lookupPodcast()', () => {
+    const podcastPayload = {
+      wrapperType: 'collection',
+      collectionId: 12345,
+      collectionName: 'Test Podcast',
+      collectionCensoredName: 'Test Podcast',
+      artistName: 'Test Author',
+      artistId: 99,
+      artworkUrl600: 'https://example.com/art600.jpg',
+      artworkUrl100: 'https://example.com/art100.jpg',
+      feedUrl: 'https://example.com/feed.xml',
+      genres: ['Tech'],
+      trackCount: 50,
+      releaseDate: '2024-06-01T00:00:00Z',
+    };
+
+    it('calls iTunes lookup with id and maps the result', () => {
+      let result: unknown;
+      service.lookupPodcast('12345').subscribe((p) => (result = p));
+
+      const req = httpMock.expectOne(
+        (r) => r.url === `${ITUNES_BASE}/lookup` && r.params.get('id') === '12345'
+      );
+      expect(req.request.params.get('country')).toBeNull();
+      req.flush({ results: [podcastPayload] });
+
+      expect((result as { id: string }).id).toBe('12345');
+      expect((result as { title: string }).title).toBe('Test Podcast');
+    });
+
+    it('passes country param when provided', () => {
+      let result: unknown;
+      service.lookupPodcast('12345', 'es').subscribe((p) => (result = p));
+
+      const req = httpMock.expectOne((r) => r.url === `${ITUNES_BASE}/lookup`);
+      expect(req.request.params.get('country')).toBe('es');
+      req.flush({ results: [podcastPayload] });
+
+      expect((result as { id: string }).id).toBe('12345');
+    });
+
+    it('throws when results array is empty', () => {
+      let error: unknown;
+      service.lookupPodcast('99999').subscribe({ error: (e) => (error = e) });
+
+      httpMock
+        .expectOne((r) => r.url === `${ITUNES_BASE}/lookup`)
+        .flush({ results: [] });
+
+      expect((error as Error).message).toBe('Podcast not found');
+    });
+  });
+
   describe('getPodcastEpisodes()', () => {
     it('filters out non-episode items', () => {
       let episodes: unknown[] = [];
@@ -182,6 +235,14 @@ describe('PodcastApiService', () => {
         });
 
       expect(episodes[0].duration).toBe(90);
+    });
+
+    it('forwards country param to the iTunes /lookup request', () => {
+      service.getPodcastEpisodes('999', 50, 'gb').subscribe();
+
+      const req = httpMock.expectOne((r) => r.url === `${ITUNES_BASE}/lookup`);
+      expect(req.request.params.get('country')).toBe('gb');
+      req.flush({ results: [] });
     });
   });
 
@@ -277,6 +338,7 @@ describe('PodcastApiService', () => {
       );
       expect(req.request.params.get('entity')).toBe('podcast');
       expect(req.request.params.get('limit')).toBe('100');
+      expect(req.request.params.get('country')).toBeNull();
 
       req.flush({
         results: [
@@ -302,6 +364,17 @@ describe('PodcastApiService', () => {
       expect(result.length).toBe(1);
       expect((result[0] as { id: string }).id).toBe('100001');
       expect((result[0] as { artistId: string }).artistId).toBe('131600381');
+    });
+
+    it('passes country param to iTunes lookup when provided', () => {
+      let result: unknown[] = [];
+
+      service.getPublisherPodcasts('131600381', 'es').subscribe((p) => (result = p));
+
+      const req = httpMock.expectOne((r) => r.url === `${ITUNES_BASE}/lookup`);
+      expect(req.request.params.get('country')).toBe('es');
+      req.flush({ results: [] });
+      expect(result.length).toBe(0);
     });
 
     it('returns empty array when only artist result is returned', () => {

--- a/src/app/core/services/podcast-api.service.ts
+++ b/src/app/core/services/podcast-api.service.ts
@@ -58,8 +58,11 @@ export class PodcastApiService {
       .pipe(map((res) => res.results.map(this.mapItunesPodcast)));
   }
 
-  lookupPodcast(itunesId: string): Observable<Podcast> {
-    const params = new HttpParams().set('id', itunesId);
+  lookupPodcast(itunesId: string, country?: string): Observable<Podcast> {
+    let params = new HttpParams().set('id', itunesId);
+    if (country) {
+      params = params.set('country', country);
+    }
     return this.http
       .get<{ results: ItunesPodcast[] }>(`${this.itunesBase}/lookup`, { params })
       .pipe(
@@ -88,12 +91,17 @@ export class PodcastApiService {
   /**
    * Fetch all podcasts published by a given iTunes artist/publisher.
    * Returns up to 100 podcasts sorted by iTunes default ranking.
+   * Pass `country` to scope results to a specific iTunes market (prevents empty
+   * results for non-US artists when the default US market is used).
    */
-  getPublisherPodcasts(artistId: string): Observable<Podcast[]> {
-    const params = new HttpParams()
+  getPublisherPodcasts(artistId: string, country?: string): Observable<Podcast[]> {
+    let params = new HttpParams()
       .set('id', artistId)
       .set('entity', 'podcast')
       .set('limit', '100');
+    if (country) {
+      params = params.set('country', country);
+    }
     return this.http
       .get<{ results: Array<ItunesPodcast | ItunesArtistResult> }>(`${this.itunesBase}/lookup`, { params })
       .pipe(
@@ -109,11 +117,12 @@ export class PodcastApiService {
    * Fetch episodes for a podcast via iTunes lookup.
    * Returns up to `limit` most recent episodes.
    */
-  getPodcastEpisodes(itunesId: string, limit = 200): Observable<Episode[]> {
-    const params = new HttpParams()
+  getPodcastEpisodes(itunesId: string, limit = 200, country?: string): Observable<Episode[]> {
+    let params = new HttpParams()
       .set('id', itunesId)
       .set('entity', 'podcastEpisode')
       .set('limit', String(limit));
+    if (country) params = params.set('country', country);
     return this.http
       .get<{ results: ItunesEpisodeRaw[] }>(`${this.itunesBase}/lookup`, { params })
       .pipe(

--- a/src/app/features/episode-detail/episode-detail.page.spec.ts
+++ b/src/app/features/episode-detail/episode-detail.page.spec.ts
@@ -1,9 +1,11 @@
 import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { BehaviorSubject, of } from 'rxjs';
 
 import { EpisodeDetailPage } from './episode-detail.page';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
+import { CountryService } from '../../core/services/country.service';
 import { PlayerStore } from '../../store/player/player.store';
 import { mockEpisode, mockPodcast } from '../../../testing/podcast-fixtures';
 import { mockPlayerStore } from '../../../testing/mock-stores';
@@ -34,6 +36,7 @@ describe('EpisodeDetailPage', () => {
           },
         },
         { provide: PlayerStore, useValue: playerStore },
+        { provide: CountryService, useValue: { country: signal('us') } },
         { provide: Router, useValue: router },
       ],
     });
@@ -99,6 +102,31 @@ describe('EpisodeDetailPage', () => {
       playerStore.queue.set([mockEpisode({ id: episode!.id })]);
       expect(component['isInQueue'] ? 'In Queue' : 'Up Next').toBe('In Queue');
     });
+  });
+
+  it('passes country to getPodcastEpisodes in strategy-3 fallback', () => {
+    // Arrange: force strategy 3 by pushing only podcastId (no episode) into navigation state
+    const episode = mockEpisode({ id: 'ep-2', podcastId: 'pod-2' });
+    const podcast = mockPodcast({ id: 'pod-2' });
+    history.pushState({ podcast: { id: 'pod-2' } }, '');
+
+    TestBed.resetTestingModule();
+    const apiMock = {
+      lookupPodcast: jest.fn().mockReturnValue(of(podcast)),
+      getPodcastEpisodes: jest.fn().mockReturnValue(of([episode])),
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ActivatedRoute, useValue: { paramMap: new BehaviorSubject(convertToParamMap({ id: 'ep-2' })).asObservable() } },
+        { provide: PodcastApiService, useValue: apiMock },
+        { provide: PlayerStore, useValue: mockPlayerStore() },
+        { provide: CountryService, useValue: { country: signal('de') } },
+        { provide: Router, useValue: { navigate: jest.fn() } },
+      ],
+    });
+    TestBed.runInInjectionContext(() => new EpisodeDetailPage());
+
+    expect(apiMock.getPodcastEpisodes).toHaveBeenCalledWith('pod-2', 50, 'de');
   });
 
 });

--- a/src/app/features/episode-detail/episode-detail.page.ts
+++ b/src/app/features/episode-detail/episode-detail.page.ts
@@ -31,6 +31,7 @@ import {
   addOutline,
 } from 'ionicons/icons';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
+import { CountryService } from '../../core/services/country.service';
 import { PlayerStore } from '../../store/player/player.store';
 import { Episode, Podcast } from '../../core/models/podcast.model';
 import { catchError, forkJoin, of, switchMap } from 'rxjs';
@@ -69,6 +70,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 export class EpisodeDetailPage {
   private readonly route = inject(ActivatedRoute);
   private readonly api = inject(PodcastApiService);
+  private readonly countryService = inject(CountryService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
   protected readonly playerStore = inject(PlayerStore);
@@ -105,7 +107,7 @@ export class EpisodeDetailPage {
           // Strategy 2: already loaded in player store
           const current = this.playerStore.currentEpisode();
           if (current?.id === episodeId) {
-            return this.api.lookupPodcast(current.podcastId).pipe(
+            return this.api.lookupPodcast(current.podcastId, this.countryService.country()).pipe(
               catchError(() => of(null)),
               switchMap((pod) => {
                 this.episode.set(current);
@@ -120,10 +122,10 @@ export class EpisodeDetailPage {
           const podcastId = navState?.podcast?.id;
           if (podcastId) {
             return forkJoin({
-              episodes: this.api.getPodcastEpisodes(podcastId, 50).pipe(
+              episodes: this.api.getPodcastEpisodes(podcastId, 50, this.countryService.country()).pipe(
                 catchError(() => of([] as Episode[])),
               ),
-              podcast: this.api.lookupPodcast(podcastId).pipe(
+              podcast: this.api.lookupPodcast(podcastId, this.countryService.country()).pipe(
                 catchError(() => of(null as Podcast | null)),
               ),
             }).pipe(

--- a/src/app/features/podcast-detail/podcast-detail.page.spec.ts
+++ b/src/app/features/podcast-detail/podcast-detail.page.spec.ts
@@ -15,6 +15,7 @@ import { of, throwError } from 'rxjs';
 
 import { PodcastDetailPage } from './podcast-detail.page';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
+import { CountryService } from '../../core/services/country.service';
 import { PodcastsStore } from '../../store/podcasts/podcasts.store';
 import { PlayerStore } from '../../store/player/player.store';
 import { AuthStore } from '../../store/auth/auth.store';
@@ -54,6 +55,7 @@ describe('PodcastDetailPage', () => {
           useValue: { paramMap: of(convertToParamMap({ id: 'pod-1' })) },
         },
         { provide: PodcastApiService, useValue: mockApi },
+        { provide: CountryService, useValue: { country: signal('us') } },
         { provide: PodcastsStore, useValue: mockPodcastsStore },
         { provide: PlayerStore, useValue: mockPlayer },
         { provide: AuthStore, useValue: mockAuth },
@@ -103,7 +105,7 @@ describe('PodcastDetailPage', () => {
     await createComponent();
 
     expect(component).toBeTruthy();
-    expect(mockApi.lookupPodcast).toHaveBeenCalledWith('pod-1');
+    expect(mockApi.lookupPodcast).toHaveBeenCalledWith('pod-1', 'us');
     // RSS feed is tried first (podcast has a feedUrl); iTunes fallback is skipped
     expect(mockApi.getEpisodesFromRss).toHaveBeenCalledWith(podcast.feedUrl, 'pod-1');
     expect(mockApi.getPodcastEpisodes).not.toHaveBeenCalled();
@@ -116,7 +118,7 @@ describe('PodcastDetailPage', () => {
     await createComponent();
 
     expect(mockApi.getEpisodesFromRss).toHaveBeenCalled();
-    expect(mockApi.getPodcastEpisodes).toHaveBeenCalledWith('pod-1', 200);
+    expect(mockApi.getPodcastEpisodes).toHaveBeenCalledWith('pod-1', 200, 'us');
     expect(component['episodes']).toHaveLength(2);
   });
 

--- a/src/app/features/podcast-detail/podcast-detail.page.ts
+++ b/src/app/features/podcast-detail/podcast-detail.page.ts
@@ -23,6 +23,7 @@ import {
 import { addIcons } from 'ionicons';
 import { checkmarkCircle, addCircleOutline, playCircleOutline, refreshOutline } from 'ionicons/icons';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
+import { CountryService } from '../../core/services/country.service';
 import { PodcastsStore } from '../../store/podcasts/podcasts.store';
 import { PlayerStore } from '../../store/player/player.store';
 import { AuthStore } from '../../store/auth/auth.store';
@@ -60,6 +61,7 @@ import { map, switchMap } from 'rxjs/operators';
 export class PodcastDetailPage {
   private readonly route = inject(ActivatedRoute);
   private readonly api = inject(PodcastApiService);
+  private readonly countryService = inject(CountryService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
   protected readonly podcastsStore = inject(PodcastsStore);
@@ -121,7 +123,7 @@ export class PodcastDetailPage {
    * A 1 s delay between retries avoids triggering iTunes rate limiting.
    */
   private loadPodcastData(id: string): Observable<{ podcast: Podcast | null; episodes: Episode[] }> {
-    return this.api.lookupPodcast(id).pipe(
+    return this.api.lookupPodcast(id, this.countryService.country()).pipe(
       retry({ count: 2, delay: 1000 }),
       catchError(() => {
         this.podcastError = 'Could not load podcast info.';
@@ -143,7 +145,7 @@ export class PodcastDetailPage {
   }
 
   private itunesEpisodes(id: string): Observable<Episode[]> {
-    return this.api.getPodcastEpisodes(id, 200).pipe(
+    return this.api.getPodcastEpisodes(id, 200, this.countryService.country()).pipe(
       retry({ count: 2, delay: 1000 }),
       catchError(() => {
         this.episodesError = 'Could not load episodes.';

--- a/src/app/features/publisher/publisher.page.spec.ts
+++ b/src/app/features/publisher/publisher.page.spec.ts
@@ -1,10 +1,11 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { BehaviorSubject, of, throwError } from 'rxjs';
 
 import { PublisherPage } from './publisher.page';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
+import { CountryService } from '../../core/services/country.service';
 import { mockPodcast } from '../../../testing/podcast-fixtures';
 
 const ARTIST_ID = '131600381';
@@ -36,6 +37,7 @@ describe('PublisherPage', () => {
           useValue: { paramMap: routeParams$.asObservable() },
         },
         { provide: PodcastApiService, useValue: mockApi },
+        { provide: CountryService, useValue: { country: signal('us') } },
         { provide: Router, useValue: mockRouter },
       ],
       schemas: [NO_ERRORS_SCHEMA],
@@ -58,7 +60,7 @@ describe('PublisherPage', () => {
 
   it('loads podcasts for the given artistId', () => {
     expect(component).toBeTruthy();
-    expect(mockApi.getPublisherPodcasts).toHaveBeenCalledWith(ARTIST_ID);
+    expect(mockApi.getPublisherPodcasts).toHaveBeenCalledWith(ARTIST_ID, 'us');
     expect((component as any).podcasts().length).toBe(20);
   });
 
@@ -105,10 +107,10 @@ describe('PublisherPage', () => {
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/podcast', 'pod-42']);
   });
 
-  it('navigates to publisher page on navigateToPublisher', () => {
+  it('calls retry() which re-fetches podcasts with country for the current artist', () => {
     const mockArtistId = '999';
     (component as any).artistId.set(mockArtistId);
     (component as any).retry();
-    expect(mockApi.getPublisherPodcasts).toHaveBeenCalledWith(mockArtistId);
+    expect(mockApi.getPublisherPodcasts).toHaveBeenCalledWith(mockArtistId, 'us');
   });
 });

--- a/src/app/features/publisher/publisher.page.ts
+++ b/src/app/features/publisher/publisher.page.ts
@@ -26,6 +26,7 @@ import { catchError, of, switchMap, tap } from 'rxjs';
 
 import { Podcast } from '../../core/models/podcast.model';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
+import { CountryService } from '../../core/services/country.service';
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
 import { PodcastCardComponent } from '../../shared/components/podcast-card/podcast-card.component';
 
@@ -55,6 +56,7 @@ const PAGE_SIZE = 12;
 })
 export class PublisherPage {
   private readonly api = inject(PodcastApiService);
+  private readonly countryService = inject(CountryService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
@@ -96,7 +98,7 @@ export class PublisherPage {
 
           this.artistId.set(id);
 
-          return this.api.getPublisherPodcasts(id).pipe(
+          return this.api.getPublisherPodcasts(id, this.countryService.country()).pipe(
             catchError(() => {
               this.error.set('Could not load this publisher. Please try again.');
               return of([] as Podcast[]);
@@ -128,7 +130,7 @@ export class PublisherPage {
     this.isLoading.set(true);
     this.error.set(null);
     this.api
-      .getPublisherPodcasts(id)
+      .getPublisherPodcasts(id, this.countryService.country())
       .pipe(
         catchError(() => {
           this.error.set('Could not load this publisher. Please try again.');


### PR DESCRIPTION
## v1.3.3 Production Release

### What's fixed
- **#178** Publisher page showed no podcasts for non-US artists — `getPublisherPodcasts()` now forwards user's iTunes market code
- **#179** 'Could not load podcast info' for non-US content — `lookupPodcast()` now country-scoped on all 3 pages (podcast detail, episode detail, publisher)
- **getPodcastEpisodes()** iTunes episode fallback also country-scoped (caught in PR review)
- QA credentials documented in CI config

### Tests
✅ 266 unit tests (+5 new)  
✅ E2E suite passing on staging