### PR TITLE
style(api): add braces to country conditional in getPodcastEpisodes

### DIFF
--- a/src/app/core/services/podcast-api.service.ts
+++ b/src/app/core/services/podcast-api.service.ts
@@ -122,7 +122,9 @@ export class PodcastApiService {
       .set('id', itunesId)
       .set('entity', 'podcastEpisode')
       .set('limit', String(limit));
-    if (country) params = params.set('country', country);
+    if (country) {
+      params = params.set('country', country);
+    }
     return this.http
       .get<{ results: ItunesEpisodeRaw[] }>(`${this.itunesBase}/lookup`, { params })
       .pipe(


### PR DESCRIPTION
Addresses review comment on #187: wrap `if (country)` in braces to match the style of `searchPodcasts()`, `lookupPodcast()`, and `getPublisherPodcasts()`.