### PR TITLE
fix(ux): tabs hidden, publisher empty, history not persisting (#189 #190 #191)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -72,6 +72,27 @@ service cloud.firestore {
       allow delete: if isOwner(uid);
     }
 
+    // Listening history: users/{uid}/history/{episodeId}
+    // create: full document required (from recordPlay)
+    // update: owner-only; request.resource.data includes existing fields so hasAll passes naturally
+    match /users/{uid}/history/{episodeId} {
+      allow read: if isOwner(uid);
+      allow create: if isOwner(uid)
+        && request.resource.data.keys().hasAll(['episodeId', 'episodeTitle', 'podcastTitle', 'imageUrl', 'position', 'duration', 'lastPlayedAt', 'completed'])
+        && request.resource.data.episodeId is string
+        && request.resource.data.episodeTitle is string
+        && request.resource.data.podcastTitle is string
+        && request.resource.data.imageUrl is string
+        && request.resource.data.position is number
+        && request.resource.data.duration is number
+        && request.resource.data.position >= 0
+        && request.resource.data.duration >= 0
+        && request.resource.data.lastPlayedAt is number
+        && request.resource.data.completed is bool;
+      allow update: if isOwner(uid);
+      allow delete: if isOwner(uid);
+    }
+
     // Catch-all for any other user subcollections (deny by default)
     match /users/{uid}/{document=**} {
       allow read, write: if false;

--- a/src/app/features/publisher/publisher.page.spec.ts
+++ b/src/app/features/publisher/publisher.page.spec.ts
@@ -1,11 +1,10 @@
-import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { BehaviorSubject, of, throwError } from 'rxjs';
 
 import { PublisherPage } from './publisher.page';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
-import { CountryService } from '../../core/services/country.service';
 import { mockPodcast } from '../../../testing/podcast-fixtures';
 
 const ARTIST_ID = '131600381';
@@ -37,7 +36,6 @@ describe('PublisherPage', () => {
           useValue: { paramMap: routeParams$.asObservable() },
         },
         { provide: PodcastApiService, useValue: mockApi },
-        { provide: CountryService, useValue: { country: signal('us') } },
         { provide: Router, useValue: mockRouter },
       ],
       schemas: [NO_ERRORS_SCHEMA],
@@ -60,7 +58,7 @@ describe('PublisherPage', () => {
 
   it('loads podcasts for the given artistId', () => {
     expect(component).toBeTruthy();
-    expect(mockApi.getPublisherPodcasts).toHaveBeenCalledWith(ARTIST_ID, 'us');
+    expect(mockApi.getPublisherPodcasts).toHaveBeenCalledWith(ARTIST_ID);
     expect((component as any).podcasts().length).toBe(20);
   });
 
@@ -107,10 +105,10 @@ describe('PublisherPage', () => {
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/podcast', 'pod-42']);
   });
 
-  it('calls retry() which re-fetches podcasts with country for the current artist', () => {
+  it('calls retry() which re-fetches podcasts for the current artist', () => {
     const mockArtistId = '999';
     (component as any).artistId.set(mockArtistId);
     (component as any).retry();
-    expect(mockApi.getPublisherPodcasts).toHaveBeenCalledWith(mockArtistId, 'us');
+    expect(mockApi.getPublisherPodcasts).toHaveBeenCalledWith(mockArtistId);
   });
 });

--- a/src/app/features/publisher/publisher.page.ts
+++ b/src/app/features/publisher/publisher.page.ts
@@ -26,7 +26,6 @@ import { catchError, of, switchMap, tap } from 'rxjs';
 
 import { Podcast } from '../../core/models/podcast.model';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
-import { CountryService } from '../../core/services/country.service';
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
 import { PodcastCardComponent } from '../../shared/components/podcast-card/podcast-card.component';
 
@@ -56,7 +55,6 @@ const PAGE_SIZE = 12;
 })
 export class PublisherPage {
   private readonly api = inject(PodcastApiService);
-  private readonly countryService = inject(CountryService);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly destroyRef = inject(DestroyRef);
@@ -98,7 +96,7 @@ export class PublisherPage {
 
           this.artistId.set(id);
 
-          return this.api.getPublisherPodcasts(id, this.countryService.country()).pipe(
+          return this.api.getPublisherPodcasts(id).pipe(
             catchError(() => {
               this.error.set('Could not load this publisher. Please try again.');
               return of([] as Podcast[]);
@@ -130,7 +128,7 @@ export class PublisherPage {
     this.isLoading.set(true);
     this.error.set(null);
     this.api
-      .getPublisherPodcasts(id, this.countryService.country())
+      .getPublisherPodcasts(id)
       .pipe(
         catchError(() => {
           this.error.set('Could not load this publisher. Please try again.');

--- a/src/app/features/tabs/tabs.component.html
+++ b/src/app/features/tabs/tabs.component.html
@@ -1,6 +1,9 @@
 <wavely-offline-banner></wavely-offline-banner>
 
 <ion-tabs>
+  @if (store.currentEpisode()) {
+    <wavely-mini-player slot="bottom" (openFull)="openFullPlayer()"></wavely-mini-player>
+  }
   <ion-tab-bar slot="bottom">
     <ion-tab-button tab="home" href="/tabs/home">
       <ion-icon name="home-outline"></ion-icon>
@@ -23,9 +26,3 @@
     </ion-tab-button>
   </ion-tab-bar>
 </ion-tabs>
-
-@if (store.currentEpisode()) {
-  <ion-footer class="ion-no-border">
-    <wavely-mini-player (openFull)="openFullPlayer()"></wavely-mini-player>
-  </ion-footer>
-}

--- a/src/app/features/tabs/tabs.component.ts
+++ b/src/app/features/tabs/tabs.component.ts
@@ -6,7 +6,6 @@ import {
   IonTabButton,
   IonIcon,
   IonLabel,
-  IonFooter,
   ModalController,
 } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
@@ -35,7 +34,6 @@ import { OfflineBannerComponent } from '../../shared/components/offline-banner/o
     IonTabButton,
     IonIcon,
     IonLabel,
-    IonFooter,
     MiniPlayerComponent,
     OfflineBannerComponent,
   ],


### PR DESCRIPTION
## Summary
Three regression bugs found in v1.3.3 testing — all fixed in this PR.

## Changes
- **Tabs hidden by mini-player (#189)**: Moved `wavely-mini-player` inside `<ion-tabs>` with `slot="bottom"` before `ion-tab-bar`. The old `ion-footer` was a sibling to `ion-tabs`, sitting at `bottom: 0` and covering the tab bar entirely when audio was playing.
- **Publisher page empty for non-US users (#190)**: Removed country param from `getPublisherPodcasts()` calls. iTunes `/lookup` restricts to that country's catalogue — many publishers only exist in the US store. Omitting country uses the global/US store.
- **History never persists (#191)**: Added Firestore security rule for `users/{uid}/history/{episodeId}`. The missing rule caused the catch-all deny to silently block all reads and writes. `create` validates all 8 `HistoryEntry` fields; `update` is owner-only so partial-field writes from `updateEntry()` succeed.

## Testing
- [x] Unit tests pass (266/266 — pre-existing library.page.spec.ts failure unchanged)
- [x] IDE diagnostics: 0 errors/warnings
- [x] 3-model adversarial review (GPT, Gemini, Opus) — 1 Firestore rule issue found and fixed before commit

## Related Issues
Closes #189
Closes #190
Closes #191