### PR TITLE
chore(release): bump version to 1.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavely/source",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",


### PR DESCRIPTION
## Summary
Version bump only — no code changes. The v1.3.4 bugfixes (tabs, publisher, history) were already merged to main via PR #194, but the version in package.json was not incremented so the CI release step skipped tagging (tag v1.3.3 already existed).

## Changes
- `package.json`: 1.3.3 → 1.3.4

## Related Issues
Closes #189
Closes #190
Closes #191