### PR TITLE
fix(publisher): v1.3.5 — publisher page now shows podcasts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavely/source",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",


### PR DESCRIPTION
## v1.3.5 Release

### Bug Fixed
**Publisher page shows no podcasts** — iTunes API returns `wrapperType: 'track'` for podcast entries in `/lookup?id={artistId}&entity=podcast` responses. The type guard filtering by `wrapperType === 'collection'` was silently discarding every result.

**Fix**: use `'kind' in r && r.kind === 'podcast'` as the discriminator. Tightened `ItunesPodcast.kind` to literal `'podcast'` type.

### Root cause history
The v1.3.4 fix (removing country param) was valid but incomplete — the real bug was the wrong filter predicate all along.

### Verification
- Build, Lint & Test ✅
- E2E ✅ (on dev→staging PR)
- 266 unit tests ✅