### PR TITLE
fix(publisher): v1.3.5 — publisher page now shows podcasts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,40 @@ jobs:
           name: coverage
           path: coverage/
           retention-days: 7
+
+  version-bump-check:
+    name: Version Bump Check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check version is bumped
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          LATEST_TAG=$(git tag --sort=-v:refname | grep '^v[0-9]' | head -1)
+          LATEST_VERSION=${LATEST_TAG#v}
+
+          echo "package.json version : $PKG_VERSION"
+          echo "Latest git tag        : ${LATEST_TAG:-none}"
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No existing tags — first release, skipping check."
+            exit 0
+          fi
+
+          # Use node's semver comparison: fail if PKG_VERSION <= LATEST_VERSION
+          node -e "
+            const [a, b] = ['$PKG_VERSION', '$LATEST_VERSION'].map(v => v.split('.').map(Number));
+            const isGreater = a[0] > b[0] || (a[0] === b[0] && a[1] > b[1]) || (a[0] === b[0] && a[1] === b[1] && a[2] > b[2]);
+            if (!isGreater) {
+              console.error('ERROR: package.json version (' + '$PKG_VERSION' + ') must be greater than latest tag (' + '$LATEST_VERSION' + ').');
+              console.error('Bump the version in package.json before merging to main.');
+              process.exit(1);
+            }
+            console.log('OK: ' + '$PKG_VERSION' + ' > ' + '$LATEST_VERSION');
+          "

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@wavely/source",
-  "version": "1.3.4",
+
+  "version": "1.3.5",
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",

--- a/src/app/core/services/podcast-api.service.spec.ts
+++ b/src/app/core/services/podcast-api.service.spec.ts
@@ -327,7 +327,7 @@ describe('PodcastApiService', () => {
   });
 
   describe('getPublisherPodcasts()', () => {
-    it('calls iTunes lookup with correct params and maps only collection results', () => {
+    it('calls iTunes lookup with correct params and maps only podcast results', () => {
       const artistId = '131600381';
       let result: unknown[] = [];
 
@@ -344,9 +344,10 @@ describe('PodcastApiService', () => {
         results: [
           // Artist record — should be filtered out
           { wrapperType: 'artist', artistId: 131600381, artistName: 'Cadena SER' },
-          // Podcast collection record — should be mapped
+          // Podcast record — should be mapped (iTunes returns wrapperType 'track' with kind 'podcast')
           {
-            wrapperType: 'collection',
+            wrapperType: 'track',
+            kind: 'podcast',
             collectionId: 100001,
             collectionName: 'Hoy por Hoy',
             artistName: 'Cadena SER',

--- a/src/app/core/services/podcast-api.service.ts
+++ b/src/app/core/services/podcast-api.service.ts
@@ -107,7 +107,7 @@ export class PodcastApiService {
       .pipe(
         map((res) =>
           res.results
-            .filter((r): r is ItunesPodcast => r.wrapperType === 'collection')
+            .filter((r): r is ItunesPodcast => 'kind' in r && r.kind === 'podcast')
             .map(this.mapItunesPodcast)
         )
       );
@@ -271,7 +271,8 @@ export class PodcastApiService {
 }
 
 interface ItunesPodcast {
-  wrapperType: 'collection';
+  wrapperType: 'collection' | 'track';
+  kind?: 'podcast';
   collectionId: number;
   collectionName: string;
   collectionCensoredName?: string;


### PR DESCRIPTION
## Summary

Merges staging (v1.3.5) into main. Resolves package.json version conflict (1.3.4 hotfix on main vs 1.3.5 on staging) — keeping 1.3.5.

### Changes included
- **fix(publisher)**: filter by `kind === 'podcast'` instead of `wrapperType === 'collection'` — fixes publisher page showing no podcasts
- **chore(ci)**: version bump gate for PRs to main
- **chore**: bump version to 1.3.5

Closes PR #202 (replaced due to merge conflict).