### PR TITLE
chore(release): promote staging → main [v1.4.1]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@wavely/source",
-  "version": "1.4.0",
+
+
+  "version": "1.4.1",
+
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",

--- a/src/app/features/library/library.page.html
+++ b/src/app/features/library/library.page.html
@@ -58,11 +58,15 @@
 
 <ion-content>
   <section class="library-section">
-    <h2 class="section-title">Recently Played</h2>
+    <div class="section-header">
+      <h2 class="section-title">Continue Listening</h2>
+      <ion-button fill="clear" size="small" class="clear-history-btn" (click)="clearHistory()">Clear</ion-button>
+    </div>
 
     <div class="history-filters" role="tablist" aria-label="History filters">
       @for (filter of historyFilters; track filter.value) {
         <ion-chip
+          button
           [class.active]="historyStore.activeFilter() === filter.value"
           [outline]="historyStore.activeFilter() !== filter.value"
           (click)="selectFilter(filter.value)">
@@ -72,12 +76,14 @@
     </div>
 
     @if (recentHistory().length === 0) {
-      <wavely-empty-state icon="time-outline" title="No listening history" subtitle="Start an episode and your recent listens will appear here."></wavely-empty-state>
+      @if (historyStore.activeFilter() === 'all') {
+        <wavely-empty-state icon="time-outline" title="Nothing in progress" subtitle="Start an episode and it will appear here to continue."></wavely-empty-state>
+      } @else {
+        <wavely-empty-state icon="time-outline" title="No episodes here" subtitle="Try a different filter."></wavely-empty-state>
+      }
     } @else {
+      <p class="list-hint">Swipe left or tap <ion-icon name="checkmark-circle-outline" style="vertical-align: middle"></ion-icon> to mark played</p>
       <ion-list lines="none">
-        <ion-button slot="end" fill="clear" size="small" class="clear-history-btn" (click)="clearHistory()">Clear history</ion-button>
-        <p class="list-hint">Swipe left to mark played or unplayed</p>
-
         @for (entry of recentHistory(); track entry.episodeId) {
           <ion-item-sliding #historyItem>
             <ion-item>
@@ -88,9 +94,11 @@
                 <h2>{{ entry.episodeTitle }}</h2>
                 <ion-note>{{ entry.podcastTitle }}</ion-note>
                 <div class="history-meta">
-                  <ion-note>{{ formatTime(entry.position) }} / {{ formatTime(entry.duration) }}</ion-note>
+                  <ion-note class="history-time">{{ formatRelativeTime(entry.lastPlayedAt) }}</ion-note>
                   @if (entry.completed) {
-                    <ion-note color="success">Completed</ion-note>
+                    <ion-note color="success">· Completed</ion-note>
+                  } @else if (entry.duration > 0) {
+                    <ion-note>· {{ formatTime(entry.duration - entry.position) }} left</ion-note>
                   }
                 </div>
                 <ion-progress-bar [value]="progressValue(entry)"></ion-progress-bar>
@@ -99,22 +107,33 @@
                 slot="end"
                 fill="clear"
                 size="small"
-                [color]="entry.completed ? 'medium' : 'success'"
+                class="mark-played-btn"
                 [attr.aria-label]="entry.completed ? 'Mark as unplayed' : 'Mark as played'"
-                (click)="entry.completed ? markUnplayed(entry.episodeId) : markPlayed(entry.episodeId)">
-                {{ entry.completed ? 'Mark as unplayed' : 'Mark as played' }}
+                (click)="entry.completed ? markUnplayed(entry.episodeId) : markPlayed(entry.episodeId)"
+              >
+                <ion-icon slot="icon-only" [name]="entry.completed ? 'radio-button-off-outline' : 'checkmark-circle-outline'"></ion-icon>
               </ion-button>
             </ion-item>
             <ion-item-options side="end">
               @if (entry.completed) {
-                <ion-item-option color="medium" (click)="markUnplayed(entry.episodeId); historyItem.close()">Mark as unplayed</ion-item-option>
+                <ion-item-option color="medium" (click)="markUnplayed(entry.episodeId); historyItem.close()">Mark unplayed</ion-item-option>
               } @else {
-                <ion-item-option color="success" (click)="markPlayed(entry.episodeId); historyItem.close()">Mark as played</ion-item-option>
+                <ion-item-option color="success" (click)="markPlayed(entry.episodeId); historyItem.close()">Mark played</ion-item-option>
               }
             </ion-item-options>
           </ion-item-sliding>
         }
       </ion-list>
+
+      @if (hiddenCount() > 0) {
+        <button type="button" class="show-all-btn" (click)="toggleShowAll()">
+          Show {{ hiddenCount() }} more episodes
+        </button>
+      } @else if (showAllHistory()) {
+        <button type="button" class="show-all-btn" (click)="toggleShowAll()">
+          Show less
+        </button>
+      }
     }
   </section>
 

--- a/src/app/features/library/library.page.scss
+++ b/src/app/features/library/library.page.scss
@@ -2,6 +2,13 @@
   padding-top: 8px;
 }
 
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-right: 8px;
+}
+
 .section-title {
   margin: 8px 16px;
   font-size: 18px;
@@ -103,9 +110,41 @@ ion-note {
   }
 }
 
+.clear-history-btn {
+  --color: var(--wavely-on-surface-muted);
+  font-size: 13px;
+}
+
 .history-meta {
   display: flex;
-  gap: 8px;
+  gap: 4px;
   align-items: center;
-  margin: 6px 0 8px;
+  margin: 4px 0 6px;
+}
+
+.history-time {
+  color: var(--wavely-on-surface-muted);
+  font-size: 11px;
+}
+
+.show-all-btn {
+  display: block;
+  width: 100%;
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  color: var(--ion-color-primary);
+  font-size: 14px;
+  font-weight: 500;
+  text-align: center;
+  cursor: pointer;
+
+  &:active {
+    opacity: 0.7;
+  }
+}
+
+.mark-played-btn {
+  --color: var(--wavely-on-surface-muted);
+  flex-shrink: 0;
 }

--- a/src/app/features/library/library.page.ts
+++ b/src/app/features/library/library.page.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { Router } from '@angular/router';
 
 import {
@@ -35,6 +35,8 @@ import {
   personCircleOutline,
   libraryOutline,
   timeOutline,
+  checkmarkCircleOutline,
+  radioButtonOffOutline,
 } from 'ionicons/icons';
 import { PodcastsStore } from '../../store/podcasts/podcasts.store';
 import { AuthStore } from '../../store/auth/auth.store';
@@ -88,7 +90,26 @@ export class LibraryPage {
   private readonly historySyncService = inject(HistorySyncService);
   private readonly router = inject(Router);
 
-  protected readonly recentHistory = computed(() => this.historyStore.filteredEntries());
+  private static readonly HISTORY_LIMIT = 10;
+
+  protected readonly showAllHistory = signal(false);
+
+  protected readonly recentHistory = computed(() => {
+    const entries = this.historyStore.filteredEntries();
+    const filter = this.historyStore.activeFilter();
+    if (filter === 'all' && !this.showAllHistory()) {
+      return entries
+        .filter((e) => !e.completed)
+        .slice(0, LibraryPage.HISTORY_LIMIT);
+    }
+    return entries;
+  });
+
+  protected readonly hiddenCount = computed(() => {
+    const filter = this.historyStore.activeFilter();
+    if (filter !== 'all' || this.showAllHistory()) return 0;
+    return this.historyStore.filteredEntries().length - this.recentHistory().length;
+  });
 
   protected readonly historyFilters: { label: string; value: HistoryFilter }[] = [
     { label: 'All', value: 'all' },
@@ -113,6 +134,8 @@ export class LibraryPage {
       personCircleOutline,
       timeOutline,
       libraryOutline,
+      checkmarkCircleOutline,
+      radioButtonOffOutline,
     });
     this.loadHistory();
   }
@@ -135,6 +158,7 @@ export class LibraryPage {
   }
 
   protected selectFilter(filter: HistoryFilter): void {
+    this.showAllHistory.set(false);
     this.historyStore.setFilter(filter);
   }
 
@@ -185,6 +209,24 @@ export class LibraryPage {
     const s = Math.floor(seconds % 60);
     if (h > 0) return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
     return `${m}:${s.toString().padStart(2, '0')}`;
+  }
+
+  protected toggleShowAll(): void {
+    this.showAllHistory.update((v) => !v);
+  }
+
+  protected formatRelativeTime(ts: number): string {
+    if (!ts) return '';
+    const diffMs = Date.now() - ts;
+    const diffMins = Math.floor(diffMs / 60_000);
+    if (diffMins < 1) return 'Just now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    if (diffDays === 1) return 'Yesterday';
+    if (diffDays < 7) return `${diffDays}d ago`;
+    return new Date(ts).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
   }
 
   protected async signOut(): Promise<void> {


### PR DESCRIPTION
## Summary
Promotes staging to main for v1.4.1 release.

## Changes (v1.4.1 — Library History UX)
- Continue Listening section with episodic progress
- Fixed remaining-time label (was showing elapsed, now shows remaining)
- Fixed icon registration (checkmarkCircleOutline, radioButtonOffOutline)
- Fixed formatRelativeTime: yesterday shows 'Yesterday' not '1d ago'
- Simplified hiddenCount calculation
- Added type="button" to prevent accidental form submission

## Version
- package.json: 1.4.0 → 1.4.1

## CI Gates
- [x] Build, Lint & Test ✅
- [x] E2E Tests ✅
- [x] Deploy preview ✅ (on staging PR)