### PR TITLE
chore(release): v1.5.2 — version bump, README & landing update

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,9 +269,20 @@ gh pr create --base dev
 - [x] Listening history UX improvements (filterable, synced to Firestore)
 - [x] Queue / Up Next UX overhaul and episode feed on Home tab
 
-### v1.5 — Navigation Restructure (planned)
-- [ ] Merge Search + Browse into a unified Discover tab
-- [ ] Radio as a dedicated hub tab
+### v1.5.0 — Navigation Restructure ✅ Shipped
+- [x] Discover tab: unified Search + Browse hub
+- [x] Radio as a dedicated hub tab
+
+### v1.5.1 — Light Theme Fix ✅ Shipped
+- [x] Light mode broken when OS was in dark mode
+- [x] Theme service hardening (SSR safety, localStorage validation)
+
+### v1.5.2 — UX Quick Wins ✅ Shipped
+- [x] Trending section first in Discover tab
+- [x] Radio station limit raised to 100 results
+- [x] Search page removed from Discover (consolidated into the tab's own search bar)
+- [x] Logout now stops the audio player
+- [x] Onboarding UX: Home shows trending when no subscriptions
 
 ### v2.0 — Native Platform
 - [ ] Push notifications ([#41](https://github.com/bndF1/wavely/issues/41))

--- a/docs/index.html
+++ b/docs/index.html
@@ -423,7 +423,7 @@
     <section class="hero">
       <div class="container hero-grid">
         <div class="hero-content">
-          <div class="badge">Early Access <span>v1.2.0</span></div>
+          <div class="badge">Early Access <span>v1.5.2</span></div>
           <h1>Your podcasts.<br>Beautifully organized.</h1>
           <p class="hero-subtitle">
             A free, open-source podcast player built with modern web technologies. Clean design, no ads, and seamless synchronization.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavely/source",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",


### PR DESCRIPTION
## v1.5.2 Release Prep

All features already merged to `dev` via PR #234. This PR just packages the release:

- Bump `package.json` version `1.5.1` → `1.5.2`
- README roadmap: split `v1.5` into `v1.5.0` / `v1.5.1` / `v1.5.2` sections, all ✅ Shipped
- Landing page version badge `v1.2.0` → `v1.5.2`

### What shipped in v1.5.2
- Trending section first in Discover tab
- Radio station limit raised to 100
- Search page removed from Discover
- Logout now stops the audio player
- Home shows trending when no subscriptions