### PR TITLE
fix(episode-item): remove dead queue output, fix thumbnail CSS class

### DIFF
--- a/src/app/shared/components/episode-item/episode-item.component.html
+++ b/src/app/shared/components/episode-item/episode-item.component.html
@@ -1,5 +1,5 @@
 <ion-item button class="episode-item" (click)="emitPlay()">
-  <ion-thumbnail slot="start" class="episode-item__thumbnail">
+  <ion-thumbnail slot="start" class="episode-item__thumb">
     <img
       [src]="episode().imageUrl || '/default-artwork.svg'"
       [alt]="episode().title"

--- a/src/app/shared/components/episode-item/episode-item.component.ts
+++ b/src/app/shared/components/episode-item/episode-item.component.ts
@@ -21,7 +21,6 @@ export class EpisodeItemComponent {
 
   readonly episodePlay = output<Episode>();
   readonly addToQueue = output<Episode>();
-  readonly queue = output<Episode>();
 
   constructor() {
     addIcons({ playCircleOutline, addOutline });
@@ -33,9 +32,7 @@ export class EpisodeItemComponent {
 
   protected emitQueue(event: Event): void {
     event.stopPropagation();
-    const episode = this.episode();
-    this.addToQueue.emit(episode);
-    this.queue.emit(episode);
+    this.addToQueue.emit(this.episode());
   }
 
   protected formatDuration(seconds: number): string {


### PR DESCRIPTION
Backport from `promote/v1.5.4-to-staging`.

- Remove dead `queue` output (never bound by any consumer)
- Fix CSS class: `episode-item__thumbnail` → `episode-item__thumb`