### PR TITLE
chore(release): bump version to 1.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavely/source",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",


### PR DESCRIPTION
Bumps package.json version to 1.5.6 ahead of promote.