### PR TITLE
fix(e2e): update player tests for router-based full player navigation

### DIFF
--- a/e2e/src/player.spec.ts
+++ b/e2e/src/player.spec.ts
@@ -109,17 +109,16 @@ test.describe('Player', () => {
   test('clicking mini player opens full player', async ({ page }) => {
     await page.locator('wavely-mini-player .mini-player').click();
 
-    const fullPlayer = page.locator('ion-modal.full-player-modal wavely-full-player');
-    await expect(fullPlayer).toBeVisible();
+    await expect(page).toHaveURL(/\/episode\//);
   });
 
   test('full player shows title and controls', async ({ page }) => {
     await page.locator('wavely-mini-player .mini-player').click();
 
-    const fullPlayer = page.locator('ion-modal.full-player-modal wavely-full-player');
-    await expect(fullPlayer.locator('.full-player__title')).toHaveText(PLAYER_EPISODE.title);
-    await expect(fullPlayer.getByRole('button', { name: /skip back 15 seconds/i })).toBeVisible();
-    await expect(fullPlayer.getByRole('button', { name: /skip forward 30 seconds/i })).toBeVisible();
-    await expect(fullPlayer.locator('button.full-player__play-pause-btn')).toBeVisible();
+    await expect(page).toHaveURL(/\/episode\//);
+    await expect(page.locator('.episode-title')).toHaveText(PLAYER_EPISODE.title);
+    await expect(page.getByRole('button', { name: /skip back 30 seconds/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /skip forward 30 seconds/i })).toBeVisible();
+    await expect(page.locator('ion-button.play-pause-btn')).toBeVisible();
   });
 });


### PR DESCRIPTION
Backports the E2E fix from v1.5.5 promote branch. Mini player now navigates to /episode/:id instead of a modal. Updates selectors accordingly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>