### PR TITLE
fix(player): swipe-down full player — add re-entrancy guard (v1.5.8)

### DIFF
--- a/src/app/features/tabs/tabs.component.spec.ts
+++ b/src/app/features/tabs/tabs.component.spec.ts
@@ -17,7 +17,7 @@ describe('TabsComponent', () => {
   let fixture: ComponentFixture<TabsComponent>;
   let component: TabsComponent;
 
-  const mockModal = { present: jest.fn().mockResolvedValue(undefined) };
+  const mockModal = { present: jest.fn().mockResolvedValue(undefined), classList: { contains: jest.fn(() => false) } };
   const mockModalCtrl = {
     create: jest.fn().mockResolvedValue(mockModal),
     getTop: jest.fn().mockResolvedValue(null),
@@ -70,5 +70,19 @@ describe('TabsComponent', () => {
     mockPlayerStore.currentEpisode.mockReturnValue(null);
     await component.openFullPlayer();
     expect(mockModalCtrl.create).not.toHaveBeenCalled();
+  });
+
+  it('does not open a second modal if one is already open', async () => {
+    mockPlayerStore.currentEpisode.mockReturnValue({ id: 'ep-123', title: 'Test' });
+    const existingModal = { classList: { contains: jest.fn(() => true) } };
+    mockModalCtrl.getTop.mockResolvedValueOnce(existingModal);
+    await component.openFullPlayer();
+    expect(mockModalCtrl.create).not.toHaveBeenCalled();
+  });
+
+  it('does not open concurrent modals on rapid taps', async () => {
+    mockPlayerStore.currentEpisode.mockReturnValue({ id: 'ep-123', title: 'Test' });
+    await Promise.all([component.openFullPlayer(), component.openFullPlayer()]);
+    expect(mockModalCtrl.create).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/features/tabs/tabs.component.ts
+++ b/src/app/features/tabs/tabs.component.ts
@@ -41,6 +41,7 @@ import { FullPlayerComponent } from '../player/full-player/full-player.component
 export class TabsComponent {
   readonly store = inject(PlayerStore);
   private readonly modalCtrl = inject(ModalController);
+  private isOpeningPlayer = false;
 
   constructor() {
     addIcons({
@@ -57,18 +58,24 @@ export class TabsComponent {
 
   async openFullPlayer(): Promise<void> {
     if (!this.store.currentEpisode()?.id) return;
+    if (this.isOpeningPlayer) return;
+    this.isOpeningPlayer = true;
+    try {
+      const existing = await this.modalCtrl.getTop();
+      if (existing?.classList.contains('full-player-modal')) return;
 
-    const existing = await this.modalCtrl.getTop();
-    if (existing?.classList.contains('full-player-modal')) return;
-
-    const modal = await this.modalCtrl.create({
-      component: FullPlayerComponent,
-      cssClass: 'full-player-modal',
-      breakpoints: [0, 1],
-      initialBreakpoint: 1,
-      handle: false,
-      canDismiss: true,
-    });
-    await modal.present();
+      const modal = await this.modalCtrl.create({
+        component: FullPlayerComponent,
+        cssClass: 'full-player-modal',
+        breakpoints: [0, 1],
+        initialBreakpoint: 1,
+        canDismiss: true,
+        handle: false,
+        showBackdrop: false,
+      });
+      await modal.present();
+    } finally {
+      this.isOpeningPlayer = false;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Strengthens the existing swipe-down modal implementation in `dev` with a re-entrancy guard to prevent duplicate modals on rapid taps.

The `ModalController` implementation was already in `dev` (PR #274) but was silently discarded during the v1.5.7 promote merge via `-X ours`. This PR ensures it stays in the pipeline.

## Changes

### `tabs.component.ts`
- Added `isOpeningPlayer` flag with `try/finally` to block concurrent `openFullPlayer()` calls
- Added `showBackdrop: false` to the modal config

### `tabs.component.spec.ts`
- Added `classList.contains` to mock modal (required for stacking guard test)
- Added test: *does not open a second modal if one is already open*
- Added test: *does not open concurrent modals on rapid taps*

## Closes
Closes #271

## Test plan
- Tap mini-player → full player slides up, swipe down to dismiss (no back arrow)
- Rapid taps on mini-player → only one modal opens