### PR TITLE
chore(release): bump version to 1.5.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavely/source",
-  "version": "1.5.7",
+  "version": "1.5.8",
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",


### PR DESCRIPTION
Version bump for v1.5.8 release — full player swipe-down modal re-entrancy guard.