### PR TITLE
chore(release): bump version to 1.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavely/source",
-  "version": "1.5.9",
+  "version": "1.5.10",
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",


### PR DESCRIPTION
Bumps `package.json` version from 1.5.9 → 1.5.10 following merge of #295.