### PR TITLE
fix(ui): v1.5.11 — fix feed-list padding and negative margin

### DIFF
--- a/src/app/features/home/home.page.scss
+++ b/src/app/features/home/home.page.scss
@@ -76,12 +76,12 @@
 
 /* Episode feed */
 .feed-list {
-  margin: 0 -16px;
+  margin: 0;
 }
 
 .feed-item {
-  --padding-start: 16px;
-  --inner-padding-end: 8px;
+  --padding-start: 0;
+  --inner-padding-end: 0;
 }
 
 .feed-thumbnail {


### PR DESCRIPTION
## Problem
`.feed-list` used `margin: 0 -16px` to cancel the section's 16px padding, then `.feed-item` re-applied `--padding-start: 16px`. But `episode-item.component.scss` forces `--padding-start: 0` on its inner `ion-item`, so the padding variable was silently ignored — leaving content flush against the left edge.

## Fix
Remove the negative margin and zero-out the CSS variable overrides. Let the section's natural `padding: 16px` provide spacing (same pattern as radio list).

## Changes
- `src/app/features/home/home.page.scss`: `.feed-list` margin `0 -16px` → `0`; `.feed-item` `--padding-start: 16px; --inner-padding-end: 8px` → `0; 0`

Closes #293