### PR TITLE
chore(release): bump version to 1.5.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavely/source",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",


### PR DESCRIPTION
Bumps `package.json` version 1.5.10 → 1.5.11 following merge of #299.