### PR TITLE
promote: v1.5.11 dev → staging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavely/source",
-  "version": "1.5.10",
+  "version": "1.5.11",
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",

--- a/src/app/features/home/home.page.scss
+++ b/src/app/features/home/home.page.scss
@@ -76,12 +76,12 @@
 
 /* Episode feed */
 .feed-list {
-  margin: 0 -16px;
+  margin: 0;
 }
 
 .feed-item {
-  --padding-start: 16px;
-  --inner-padding-end: 8px;
+  --padding-start: 0;
+  --inner-padding-end: 0;
 }
 
 .feed-thumbnail {


### PR DESCRIPTION
Promotes v1.5.11 feed-list padding fix and version bump from `dev` to `staging`.