### PR TITLE
chore(release): bump version to 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavely/source",
-  "version": "1.5.11",
+  "version": "1.6.0",
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",


### PR DESCRIPTION
Bump `package.json` version from `1.5.11` → `1.6.0` ahead of the staging promote.