### PR TITLE
fix(i18n): patch E2E breakage — episode translations, skip_back seconds, subscribe aria-label

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -93,7 +93,7 @@
   "player": {
     "play": "Play",
     "pause": "Pause",
-    "skip_back": "Skip back 30 seconds",
+    "skip_back": "Skip back 15 seconds",
     "skip_forward": "Skip forward 30 seconds",
     "previous_episode": "Previous episode",
     "next_episode": "Next episode",
@@ -137,6 +137,10 @@
     "cancel": "Cancel",
     "close": "Close",
     "search": "Search"
+  },
+  "episode": {
+    "play": "Play",
+    "add_to_queue": "Add to queue"
   },
   "languages": {
     "en": "English",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -93,7 +93,7 @@
   "player": {
     "play": "Reproducir",
     "pause": "Pausar",
-    "skip_back": "Retroceder 30 segundos",
+    "skip_back": "Retroceder 15 segundos",
     "skip_forward": "Avanzar 30 segundos",
     "previous_episode": "Episodio anterior",
     "next_episode": "Episodio siguiente",
@@ -144,5 +144,9 @@
     "fr": "Français",
     "de": "Deutsch",
     "pt": "Português"
+  },
+  "episode": {
+    "play": "Reproducir",
+    "add_to_queue": "Añadir a la cola"
   }
 }

--- a/src/app/features/podcast-detail/podcast-detail.page.html
+++ b/src/app/features/podcast-detail/podcast-detail.page.html
@@ -71,6 +71,7 @@
           [color]="isSubscribed ? 'primary' : 'medium'"
           size="small"
           shape="round"
+          [attr.aria-label]="isSubscribed ? ('podcast_detail.subscribed' | translate) : ('podcast_detail.subscribe' | translate)"
           (click)="toggleSubscription()">
           <ion-icon
             slot="start"

--- a/src/app/shared/components/episode-item/episode-item.component.html
+++ b/src/app/shared/components/episode-item/episode-item.component.html
@@ -33,7 +33,7 @@
     slot="end"
     fill="clear"
     size="small"
-    [attr.aria-label]="('episode.add_to_queue' | translate) + ': ' + episode().title"
+    [attr.aria-label]="('episode.add_to_queue' | translate) + ' ' + episode().title"
     (click)="emitQueue($event)">
     <ion-icon slot="icon-only" [name]="justAdded() ? 'checkmark-outline' : 'add-outline'"></ion-icon>
   </ion-button>
@@ -42,7 +42,7 @@
     slot="end"
     fill="clear"
     size="small"
-    [attr.aria-label]="('episode.play' | translate) + ': ' + episode().title"
+    [attr.aria-label]="('episode.play' | translate) + ' ' + episode().title"
     (click)="emitPlay(); $event.stopPropagation()">
     <ion-icon slot="icon-only" name="play-circle-outline"></ion-icon>
   </ion-button>


### PR DESCRIPTION
## Problem

PR #308 (dev→staging) E2E suite failed with 6 failures caused by i18n work in v1.7.0:

### Root causes
1. **episode-item aria-labels** — `episode-item.component.html` uses `('episode.play' | translate) + ': ' + title` but no `episode` key existed in `en.json`/`es.json`, so translate pipe returned the key verbatim. E2E `beforeEach` uses exact match `'Play Mini Player Episode'`.
2. **skip_back label** — `en.json` had 'Skip back 30 seconds' but the button skips 15s. E2E expects `/skip back 15 seconds/i`.
3. **subscribe button** — `ion-button` had no explicit `aria-label`, making Playwright `getByRole` unreliable with async translate pipe in Ionic shadow DOM.

### Fixes
- Add `episode.play` / `episode.add_to_queue` keys to `en.json` and `es.json`
- Change `player.skip_back` from '30 seconds' → '15 seconds' in both locales
- Fix aria-label separator in `episode-item`: `': '` → `' '` (matches E2E exact selector)
- Add explicit `[attr.aria-label]` binding to subscribe `ion-button` in `podcast-detail.page.html`

Unblocks PR #308 auto-merge.