### PR TITLE
fix(i18n): load translations at app startup, not lazily from SettingsPage

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -49,7 +49,7 @@ export const appConfig: ApplicationConfig = {
     provideRouter(appRoutes, withPreloading(PreloadAllModules)),
     provideHttpClient(withFetch()),
     importProvidersFrom(
-      TranslateModule.forRoot({ defaultLanguage: 'en' }),
+      TranslateModule.forRoot({ fallbackLang: 'en' }),
     ),
     ...provideTranslateHttpLoader({ prefix: '/i18n/', suffix: '.json' }),
     provideFirebaseApp(() => getApp()),

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -8,6 +8,7 @@ import { AudioService } from './core/services/audio.service';
 import { AuthService } from './core/auth/auth.service';
 import { AuthStore } from './store/auth/auth.store';
 import { ThemeService } from './core/services/theme.service';
+import { LanguageService } from './core/services/language.service';
 import { environment } from '../environments/environment';
 
 @Component({
@@ -24,6 +25,9 @@ export class App {
   // Injecting ThemeService here ensures the saved theme is applied before
   // the first render, avoiding a flash of the wrong color scheme.
   private readonly _theme = inject(ThemeService);
+  // Injecting LanguageService here ensures translate.use(lang) is called
+  // at app startup so translations are loaded before any component renders.
+  private readonly _lang = inject(LanguageService);
   private readonly authStore = inject(AuthStore);
   private readonly router = inject(Router);
 


### PR DESCRIPTION
## Root cause

ngx-translate v17 deprecated the `defaultLanguage` option. It is now a **no-op** unless `useDefaultLang: true` is also set (which it wasn't). As a result:
- No fallback language was ever configured
- No translation file was ever fetched at startup
- `LanguageService` was only injected in `SettingsPage`, so `translate.use(lang)` only fired if the user visited Settings

This caused translate pipes to return i18n **keys verbatim** throughout the entire app for every user who hadn't visited Settings — and for every E2E test that didn't navigate through Settings.

## Failing E2E tests (all caused by this)
- `player.spec.ts` — `getByRole('button', { name: 'Play Mini Player Episode' })` never found (aria-label = `episode.play` key)
- `podcast-detail.spec.ts` — `getByRole('button', { name: /^subscribe$/i })` never found (text = `podcast_detail.subscribe` key)
- `home.spec.ts` — click on `ion-button` with text matching `/Subscribe/i` never found

## Fix

Two surgical changes:

1. **`app.config.ts`**: `TranslateModule.forRoot({ fallbackLang: 'en' })` — the correct v17 API. Causes TranslateService to load `en.json` as fallback immediately on first injection.

2. **`app.ts`**: inject `LanguageService` in `AppComponent` (same pattern as `ThemeService`). Forces `translate.use(lang)` to fire at app startup, before any lazy-loaded page renders.

## Verification
- Build: passes
- Unit tests: 285/285