### PR TITLE
chore(release): promote v1.8.0 to main

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,8 @@
         "@ionic/angular": "^8.8.1",
         "@ionic/angular-toolkit": "^12.3.0",
         "@ngrx/signals": "^21.0.1",
+        "@ngx-translate/core": "^17.0.0",
+        "@ngx-translate/http-loader": "^17.0.0",
         "@sentry/angular": "^10.43.0",
         "express": "^4.21.2",
         "firebase": "^12.10.0",
@@ -912,6 +914,10 @@
     "@ngrx/signals": ["@ngrx/signals@21.0.1", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/core": "^21.0.0", "rxjs": "^6.5.3 || ^7.4.0" }, "optionalPeers": ["rxjs"] }, "sha512-krmZDhgHrnmZrxfEJ41bp/aM8Mc55k5B2N7oCLT5w4M3YbOkbnWPkP6bBWMv4XPI+2rqVgkLRW6DaWLwoESaBw=="],
 
     "@ngtools/webpack": ["@ngtools/webpack@21.1.5", "", { "peerDependencies": { "@angular/compiler-cli": "^21.0.0", "typescript": ">=5.9 <6.0", "webpack": "^5.54.0" } }, "sha512-5nG9v/nEzsaKxgw5NurM6tPKPw0OYsCM3DL4ZI8+TidT55hYbsroTnyBcHBouJ1qlZlQXNtlsjsjBmBDtF7JZA=="],
+
+    "@ngx-translate/core": ["@ngx-translate/core@17.0.0", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/common": ">=16", "@angular/core": ">=16" } }, "sha512-Rft2D5ns2pq4orLZjEtx1uhNuEBerUdpFUG1IcqtGuipj6SavgB8SkxtNQALNDA+EVlvsNCCjC2ewZVtUeN6rg=="],
+
+    "@ngx-translate/http-loader": ["@ngx-translate/http-loader@17.0.0", "", { "dependencies": { "tslib": "^2.3.0" }, "peerDependencies": { "@angular/common": ">=16", "@angular/core": ">=16" } }, "sha512-hgS8sa0ARjH9ll3PhkLTufeVXNI2DNR2uFKDhBgq13siUXzzVr/a31M6zgecrtwbA34iaBV01hsTMbMS8V7iIw=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wavely/source",
-  "version": "1.6.0",
+  "version": "1.8.0",
   "license": "MIT",
   "scripts": {
     "generate-env": "node --env-file=.env scripts/generate-env.mjs",
@@ -39,6 +39,8 @@
     "@ionic/angular": "^8.8.1",
     "@ionic/angular-toolkit": "^12.3.0",
     "@ngrx/signals": "^21.0.1",
+    "@ngx-translate/core": "^17.0.0",
+    "@ngx-translate/http-loader": "^17.0.0",
     "@sentry/angular": "^10.43.0",
     "express": "^4.21.2",
     "firebase": "^12.10.0",

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1,0 +1,152 @@
+{
+  "nav": {
+    "home": "Home",
+    "discover": "Discover",
+    "radio": "Radio",
+    "library": "Library"
+  },
+  "home": {
+    "title": "Wavely",
+    "my_podcasts": "My Podcasts",
+    "latest_episodes": "Latest Episodes",
+    "trending": "Trending",
+    "trending_subtitle": "Discover what's popular and subscribe to personalise your feed.",
+    "load_more": "Load {{count}} more episodes",
+    "error_trending": "Could not load trending podcasts. Pull down to retry.",
+    "error_feed": "Could not load episodes. Pull down to retry.",
+    "retry": "Retry",
+    "favorite_stations": "Favorite Stations"
+  },
+  "browse": {
+    "title": "Browse",
+    "trending_now": "Trending Now",
+    "categories": "Browse by Category",
+    "no_podcasts": "No podcasts available",
+    "no_podcasts_subtitle": "Try refreshing or check back later.",
+    "error_load": "Could not load browse",
+    "refresh": "Refresh",
+    "retry": "Retry",
+    "error_subtitle": "Try refreshing or check back later.",
+    "listen_now": "Listen Now",
+    "more_in": "More in"
+  },
+  "library": {
+    "title": "Library",
+    "continue_listening": "Continue Listening",
+    "clear": "Clear",
+    "subscriptions": "Subscriptions",
+    "settings": "Settings",
+    "sign_out": "Sign out",
+    "empty_subscriptions_title": "No subscriptions yet",
+    "empty_subscriptions_subtitle": "Browse podcasts and subscribe to build your library.",
+    "empty_history_progress_title": "Nothing in progress",
+    "empty_history_progress_subtitle": "Start an episode and it will appear here to continue.",
+    "empty_history_filter_title": "No episodes here",
+    "empty_history_filter_subtitle": "Try a different filter.",
+    "browse_podcasts": "Browse Podcasts",
+    "show_all": "Show all",
+    "show_less": "Show less",
+    "filter_all": "All",
+    "filter_unplayed": "Unplayed",
+    "filter_in_progress": "In Progress",
+    "filter_completed": "Completed",
+    "unsubscribe": "Unsubscribe"
+  },
+  "settings": {
+    "title": "Settings",
+    "appearance": "Appearance",
+    "theme_system": "System default",
+    "theme_light": "Light",
+    "theme_dark": "Dark",
+    "playback": "Playback",
+    "auto_queue": "Auto-queue",
+    "auto_queue_note": "Automatically queue remaining episodes when you play one",
+    "language": "Language",
+    "language_note": "App display language",
+    "about": "About",
+    "version": "Version"
+  },
+  "discover": {
+    "title": "Discover",
+    "search_placeholder": "Search podcasts and episodes...",
+    "results_for": "Results for",
+    "podcasts": "Podcasts",
+    "episodes": "Episodes",
+    "trending": "Trending",
+    "no_results_title": "No results found",
+    "no_results_subtitle": "Try searching with different keywords.",
+    "error_title": "Search failed",
+    "error_subtitle": "Check your connection and try again.",
+    "searching_for": "Results for",
+    "search_placeholder_hint": "Try searching for a topic, show, or person"
+  },
+  "radio": {
+    "title": "Radio",
+    "worldwide": "Worldwide",
+    "empty_title": "No stations found",
+    "empty_subtitle": "Try a different search or filter",
+    "error_title": "Could not load stations",
+    "error_subtitle": "Check your connection and try again.",
+    "retry": "Retry",
+    "language": "Language"
+  },
+  "player": {
+    "play": "Play",
+    "pause": "Pause",
+    "skip_back": "Skip back 15 seconds",
+    "skip_forward": "Skip forward 30 seconds",
+    "previous_episode": "Previous episode",
+    "next_episode": "Next episode",
+    "add_to_queue": "Add to queue",
+    "live": "LIVE",
+    "up_next": "Up Next",
+    "empty_queue": "No episodes in queue",
+    "close": "Close player",
+    "queue": "Queue",
+    "playback_rate": "Playback rate",
+    "play_stream": "Play stream"
+  },
+  "podcast_detail": {
+    "episodes": "Episodes",
+    "subscribe": "Subscribe",
+    "unsubscribe": "Unsubscribe",
+    "subscribed": "Subscribed",
+    "play_latest": "Play latest",
+    "website": "Website",
+    "error_title": "Could not load podcast",
+    "error_subtitle": "Check your connection and try again.",
+    "retry": "Retry",
+    "no_episodes_title": "No episodes available",
+    "no_episodes_subtitle": "Check back later for new episodes."
+  },
+  "publisher": {
+    "podcasts": "Podcasts",
+    "error_title": "Could not load publisher",
+    "retry": "Retry",
+    "title": "Publisher",
+    "error_subtitle": "Check your connection and try again."
+  },
+  "offline": {
+    "message": "You are offline. Some content may be unavailable.",
+    "dismiss": "Dismiss offline warning"
+  },
+  "common": {
+    "loading": "Loading...",
+    "error": "Something went wrong",
+    "retry": "Retry",
+    "cancel": "Cancel",
+    "close": "Close",
+    "search": "Search"
+  },
+  "episode": {
+    "play": "Play",
+    "add_to_queue": "Add to queue"
+  },
+  "languages": {
+    "en": "English",
+    "es": "Español",
+    "fr": "Français",
+    "de": "Deutsch",
+    "pt": "Português"
+  }
+}

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1,0 +1,152 @@
+{
+  "nav": {
+    "home": "Inicio",
+    "discover": "Descubrir",
+    "radio": "Radio",
+    "library": "Biblioteca"
+  },
+  "home": {
+    "title": "Wavely",
+    "my_podcasts": "Mis Podcasts",
+    "latest_episodes": "Últimos Episodios",
+    "trending": "Tendencias",
+    "trending_subtitle": "Descubre lo más popular y suscríbete para personalizar tu feed.",
+    "load_more": "Cargar {{count}} episodios más",
+    "error_trending": "No se pudieron cargar los podcasts en tendencia. Desliza hacia abajo para reintentar.",
+    "error_feed": "No se pudieron cargar los episodios. Desliza hacia abajo para reintentar.",
+    "retry": "Reintentar",
+    "favorite_stations": "Estaciones Favoritas"
+  },
+  "browse": {
+    "title": "Explorar",
+    "trending_now": "Tendencias ahora",
+    "categories": "Explorar por Categoría",
+    "no_podcasts": "No hay podcasts disponibles",
+    "no_podcasts_subtitle": "Intenta actualizar o vuelve más tarde.",
+    "error_load": "No se pudo cargar el explorador",
+    "refresh": "Actualizar",
+    "retry": "Reintentar",
+    "error_subtitle": "Intenta actualizar o vuelve más tarde.",
+    "listen_now": "Escuchar ahora",
+    "more_in": "Más en"
+  },
+  "library": {
+    "title": "Biblioteca",
+    "continue_listening": "Seguir Escuchando",
+    "clear": "Limpiar",
+    "subscriptions": "Suscripciones",
+    "settings": "Ajustes",
+    "sign_out": "Cerrar sesión",
+    "empty_subscriptions_title": "Aún no hay suscripciones",
+    "empty_subscriptions_subtitle": "Explora podcasts y suscríbete para construir tu biblioteca.",
+    "empty_history_progress_title": "Nada en progreso",
+    "empty_history_progress_subtitle": "Empieza un episodio y aparecerá aquí para continuar.",
+    "empty_history_filter_title": "No hay episodios aquí",
+    "empty_history_filter_subtitle": "Prueba con un filtro diferente.",
+    "browse_podcasts": "Explorar Podcasts",
+    "show_all": "Ver todo",
+    "show_less": "Ver menos",
+    "filter_all": "Todo",
+    "filter_unplayed": "No escuchados",
+    "filter_in_progress": "En progreso",
+    "filter_completed": "Completados",
+    "unsubscribe": "Cancelar suscripción"
+  },
+  "settings": {
+    "title": "Ajustes",
+    "appearance": "Apariencia",
+    "theme_system": "Predeterminado del sistema",
+    "theme_light": "Claro",
+    "theme_dark": "Oscuro",
+    "playback": "Reproducción",
+    "auto_queue": "Cola automática",
+    "auto_queue_note": "Agregar automáticamente los episodios restantes a la cola al reproducir uno",
+    "language": "Idioma",
+    "language_note": "Idioma de la aplicación",
+    "about": "Acerca de",
+    "version": "Versión"
+  },
+  "discover": {
+    "title": "Descubrir",
+    "search_placeholder": "Buscar podcasts y episodios...",
+    "results_for": "Resultados de",
+    "podcasts": "Podcasts",
+    "episodes": "Episodios",
+    "trending": "Tendencias",
+    "no_results_title": "Sin resultados",
+    "no_results_subtitle": "Intenta buscar con palabras clave diferentes.",
+    "error_title": "Búsqueda fallida",
+    "error_subtitle": "Comprueba tu conexión e inténtalo de nuevo.",
+    "searching_for": "Resultados de",
+    "search_placeholder_hint": "Busca un tema, programa o persona"
+  },
+  "radio": {
+    "title": "Radio",
+    "worldwide": "Mundial",
+    "empty_title": "No se encontraron emisoras",
+    "empty_subtitle": "Prueba una búsqueda o filtro diferente",
+    "error_title": "No se pudieron cargar las emisoras",
+    "error_subtitle": "Comprueba tu conexión e inténtalo de nuevo.",
+    "retry": "Reintentar",
+    "language": "Idioma"
+  },
+  "player": {
+    "play": "Reproducir",
+    "pause": "Pausar",
+    "skip_back": "Retroceder 15 segundos",
+    "skip_forward": "Avanzar 30 segundos",
+    "previous_episode": "Episodio anterior",
+    "next_episode": "Episodio siguiente",
+    "add_to_queue": "Añadir a la cola",
+    "live": "EN VIVO",
+    "up_next": "A continuación",
+    "empty_queue": "No hay episodios en la cola",
+    "close": "Cerrar reproductor",
+    "queue": "Cola",
+    "playback_rate": "Velocidad de reproducción",
+    "play_stream": "Reproducir stream"
+  },
+  "podcast_detail": {
+    "episodes": "Episodios",
+    "subscribe": "Suscribirse",
+    "unsubscribe": "Cancelar suscripción",
+    "subscribed": "Suscrito",
+    "play_latest": "Reproducir último",
+    "website": "Sitio web",
+    "error_title": "No se pudo cargar el podcast",
+    "error_subtitle": "Comprueba tu conexión e inténtalo de nuevo.",
+    "retry": "Reintentar",
+    "no_episodes_title": "No hay episodios disponibles",
+    "no_episodes_subtitle": "Vuelve más tarde para nuevos episodios."
+  },
+  "publisher": {
+    "podcasts": "Podcasts",
+    "error_title": "No se pudo cargar el editor",
+    "retry": "Reintentar",
+    "title": "Editorial",
+    "error_subtitle": "Comprueba tu conexión e inténtalo de nuevo."
+  },
+  "offline": {
+    "message": "Estás sin conexión. Puede que algún contenido no esté disponible.",
+    "dismiss": "Descartar aviso de sin conexión"
+  },
+  "common": {
+    "loading": "Cargando...",
+    "error": "Algo salió mal",
+    "retry": "Reintentar",
+    "cancel": "Cancelar",
+    "close": "Cerrar",
+    "search": "Buscar"
+  },
+  "languages": {
+    "en": "English",
+    "es": "Español",
+    "fr": "Français",
+    "de": "Deutsch",
+    "pt": "Português"
+  },
+  "episode": {
+    "play": "Reproducir",
+    "add_to_queue": "Añadir a la cola"
+  }
+}

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -4,6 +4,7 @@ import {
   ErrorHandler,
   isDevMode,
   provideBrowserGlobalErrorListeners,
+  importProvidersFrom,
 } from '@angular/core';
 import { provideHttpClient, withFetch } from '@angular/common/http';
 import { PreloadAllModules, Router, provideRouter, withPreloading } from '@angular/router';
@@ -29,6 +30,8 @@ import {
 } from '@angular/fire/firestore';
 import { provideIonicAngular } from '@ionic/angular/standalone';
 import * as Sentry from '@sentry/angular';
+import { TranslateModule } from '@ngx-translate/core';
+import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
 import { environment } from '../environments/environment';
 import { appRoutes } from './app.routes';
 
@@ -45,6 +48,10 @@ export const appConfig: ApplicationConfig = {
     provideClientHydration(withEventReplay()),
     provideRouter(appRoutes, withPreloading(PreloadAllModules)),
     provideHttpClient(withFetch()),
+    importProvidersFrom(
+      TranslateModule.forRoot({ fallbackLang: 'en' }),
+    ),
+    ...provideTranslateHttpLoader({ prefix: '/i18n/', suffix: '.json' }),
     provideFirebaseApp(() => getApp()),
     provideAuth(() => {
       if (environment.useEmulators) {

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -8,6 +8,7 @@ import { AudioService } from './core/services/audio.service';
 import { AuthService } from './core/auth/auth.service';
 import { AuthStore } from './store/auth/auth.store';
 import { ThemeService } from './core/services/theme.service';
+import { LanguageService } from './core/services/language.service';
 import { environment } from '../environments/environment';
 
 @Component({
@@ -24,6 +25,9 @@ export class App {
   // Injecting ThemeService here ensures the saved theme is applied before
   // the first render, avoiding a flash of the wrong color scheme.
   private readonly _theme = inject(ThemeService);
+  // Injecting LanguageService here ensures translate.use(lang) is called
+  // at app startup so translations are loaded before any component renders.
+  private readonly _lang = inject(LanguageService);
   private readonly authStore = inject(AuthStore);
   private readonly router = inject(Router);
 

--- a/src/app/core/services/language.service.ts
+++ b/src/app/core/services/language.service.ts
@@ -1,0 +1,58 @@
+import { inject, Injectable, PLATFORM_ID, signal } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { TranslateService } from '@ngx-translate/core';
+
+export interface SupportedLanguage {
+  code: string;
+  label: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class LanguageService {
+  private static readonly STORAGE_KEY = 'wavely:language';
+
+  readonly supported: SupportedLanguage[] = [
+    { code: 'en', label: 'English' },
+    { code: 'es', label: 'Español' },
+    { code: 'fr', label: 'Français' },
+    { code: 'de', label: 'Deutsch' },
+    { code: 'pt', label: 'Português' },
+  ];
+
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly translate = inject(TranslateService);
+
+  readonly current = signal<string>('en');
+
+  constructor() {
+    this.translate.setDefaultLang('en');
+    const lang = this.resolveInitialLanguage();
+    this.current.set(lang);
+    this.translate.use(lang);
+  }
+
+  setLanguage(code: string): void {
+    if (!this.supported.some((l) => l.code === code)) return;
+    this.current.set(code);
+    this.translate.use(code);
+    if (isPlatformBrowser(this.platformId)) {
+      try {
+        localStorage.setItem(LanguageService.STORAGE_KEY, code);
+      } catch {
+        // ignore storage errors
+      }
+    }
+  }
+
+  private resolveInitialLanguage(): string {
+    if (!isPlatformBrowser(this.platformId)) return 'en';
+    try {
+      const saved = localStorage.getItem(LanguageService.STORAGE_KEY);
+      if (saved && this.supported.some((l) => l.code === saved)) return saved;
+    } catch {
+      // ignore storage errors
+    }
+    const browser = navigator.language.split('-')[0].toLowerCase();
+    return this.supported.some((l) => l.code === browser) ? browser : 'en';
+  }
+}

--- a/src/app/core/services/user-preferences.service.ts
+++ b/src/app/core/services/user-preferences.service.ts
@@ -1,16 +1,18 @@
 import { isPlatformBrowser } from '@angular/common';
 import { Injectable, PLATFORM_ID, inject, signal } from '@angular/core';
 
+import { RadioStation } from '../models/radio-station.model';
+
 const PREFS_KEY = 'wavely:prefs';
 
 interface WavelyPreferences {
   autoQueueEnabled: boolean;
-  favoriteStationIds: string[];
+  favoriteStations: RadioStation[];
 }
 
 const DEFAULTS: WavelyPreferences = {
   autoQueueEnabled: true,
-  favoriteStationIds: [],
+  favoriteStations: [],
 };
 
 @Injectable({ providedIn: 'root' })
@@ -18,25 +20,61 @@ export class UserPreferencesService {
   private readonly platformId = inject(PLATFORM_ID);
 
   readonly autoQueueEnabled = signal<boolean>(this.load().autoQueueEnabled);
-  readonly favoriteStationIds = signal<string[]>(this.load().favoriteStationIds);
+  readonly favoriteStations = signal<RadioStation[]>(this.load().favoriteStations);
+
+  /** Legacy IDs (string[]) found in old localStorage format — radio page migrates these on station load. */
+  readonly pendingMigrationIds = signal<string[]>(this.loadLegacyIds());
 
   setAutoQueueEnabled(value: boolean): void {
     this.autoQueueEnabled.set(value);
     this.persist({ autoQueueEnabled: value });
   }
 
-  toggleFavorite(stationuuid: string): void {
-    const currentIds = this.favoriteStationIds();
-    const nextIds = currentIds.includes(stationuuid)
-      ? currentIds.filter((id) => id !== stationuuid)
-      : [...currentIds, stationuuid];
+  toggleFavorite(station: RadioStation): void {
+    const current = this.favoriteStations();
+    const next = current.some((s) => s.stationuuid === station.stationuuid)
+      ? current.filter((s) => s.stationuuid !== station.stationuuid)
+      : [...current, station];
 
-    this.favoriteStationIds.set(nextIds);
-    this.persist({ favoriteStationIds: nextIds });
+    this.favoriteStations.set(next);
+    this.persist({ favoriteStations: next });
   }
 
   isFavorite(stationuuid: string): boolean {
-    return this.favoriteStationIds().includes(stationuuid);
+    return this.favoriteStations().some((s) => s.stationuuid === stationuuid);
+  }
+
+  /** Called by RadioPage after loading stations — migrates any legacy ID-only favorites. */
+  migrateLegacyFavorites(loadedStations: RadioStation[]): void {
+    const pendingIds = this.pendingMigrationIds();
+    if (pendingIds.length === 0) return;
+
+    const toMigrate = loadedStations.filter(
+      (s) => pendingIds.includes(s.stationuuid) && !this.isFavorite(s.stationuuid),
+    );
+    if (toMigrate.length === 0) {
+      this.pendingMigrationIds.set([]);
+      return;
+    }
+
+    const merged = [...this.favoriteStations(), ...toMigrate];
+    this.favoriteStations.set(merged);
+    this.pendingMigrationIds.set([]);
+    this.persist({ favoriteStations: merged });
+  }
+
+  private loadLegacyIds(): string[] {
+    if (!isPlatformBrowser(this.platformId)) return [];
+    try {
+      const raw = localStorage.getItem(PREFS_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      const hasNew = Array.isArray(parsed.favoriteStations) && parsed.favoriteStations.length > 0;
+      const hasLegacy = Array.isArray(parsed.favoriteStationIds) && parsed.favoriteStationIds.length > 0;
+      return !hasNew && hasLegacy ? (parsed.favoriteStationIds as string[]) : [];
+    } catch {
+      return [];
+    }
   }
 
   private load(): WavelyPreferences {
@@ -44,7 +82,13 @@ export class UserPreferencesService {
 
     try {
       const raw = localStorage.getItem(PREFS_KEY);
-      return raw ? { ...DEFAULTS, ...JSON.parse(raw) } : { ...DEFAULTS };
+      if (!raw) return { ...DEFAULTS };
+      const parsed = JSON.parse(raw);
+      return {
+        autoQueueEnabled: parsed.autoQueueEnabled ?? DEFAULTS.autoQueueEnabled,
+        // Migrate legacy favoriteStationIds (string[]) — drop them, objects not available
+        favoriteStations: Array.isArray(parsed.favoriteStations) ? parsed.favoriteStations : [],
+      };
     } catch {
       return { ...DEFAULTS };
     }
@@ -56,7 +100,7 @@ export class UserPreferencesService {
     try {
       const current: WavelyPreferences = {
         autoQueueEnabled: this.autoQueueEnabled(),
-        favoriteStationIds: this.favoriteStationIds(),
+        favoriteStations: this.favoriteStations(),
       };
       localStorage.setItem(PREFS_KEY, JSON.stringify({ ...current, ...patch }));
     } catch {

--- a/src/app/features/browse/browse.page.html
+++ b/src/app/features/browse/browse.page.html
@@ -1,6 +1,6 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>Browse</ion-title>
+    <ion-title>{{ 'browse.title' | translate }}</ion-title>
     <ion-buttons slot="end">
       <ion-button
         class="country-toggle"
@@ -14,7 +14,7 @@
 
 <ion-content>
   <section class="browse-section">
-    <h2 class="section-title">Trending Now</h2>
+    <h2 class="section-title">{{ 'browse.trending_now' | translate }}</h2>
 
     @if (isLoading()) {
       <div class="podcast-grid" aria-label="Loading trending podcasts">
@@ -41,9 +41,9 @@
     @if (error() && !isLoading()) {
       <wavely-empty-state
         icon="alert-circle-outline"
-        title="Could not load browse"
-        [subtitle]="error()!"
-        actionLabel="Retry"
+        [title]="'browse.error_load' | translate"
+        [subtitle]="'browse.error_subtitle' | translate"
+        [actionLabel]="'browse.retry' | translate"
         (action)="retryCurrentCategory()">
       </wavely-empty-state>
     }
@@ -51,9 +51,9 @@
     @if (!isLoading() && !error() && topPodcasts().length === 0) {
       <wavely-empty-state
         icon="search-outline"
-        title="No podcasts available"
-        subtitle="Try refreshing or check back later."
-        actionLabel="Refresh"
+        [title]="'browse.no_podcasts' | translate"
+        [subtitle]="'browse.no_podcasts_subtitle' | translate"
+        [actionLabel]="'browse.refresh' | translate"
         (action)="retryCurrentCategory()">
       </wavely-empty-state>
     }
@@ -82,7 +82,7 @@
   </div>
 
   <section class="browse-section">
-    <h2 class="section-title">Top in News</h2>
+    <h2 class="section-title">{{ 'browse.more_in' | translate }} News</h2>
 
     @if (isLoading()) {
       <div class="podcast-carousel" aria-label="Loading top news podcasts">
@@ -110,7 +110,7 @@
   </section>
 
   <section class="browse-section">
-    <h2 class="section-title">Top in Technology</h2>
+    <h2 class="section-title">{{ 'browse.more_in' | translate }} Technology</h2>
 
     @if (isLoading()) {
       <div class="podcast-carousel" aria-label="Loading top technology podcasts">
@@ -141,7 +141,7 @@
   <section class="browse-section">
     <h2 class="section-title">
       <ion-icon name="radio-outline" class="section-title__icon"></ion-icon>
-      Live Radio
+      {{ 'radio.title' | translate }}
     </h2>
 
     @if (isRadioLoading()) {
@@ -161,17 +161,17 @@
     } @else if (radioError()) {
       <wavely-empty-state
         icon="alert-circle-outline"
-        title="Could not load radio"
+        [title]="'radio.error_title' | translate"
         [subtitle]="radioError()!"
-        actionLabel="Retry"
+        [actionLabel]="'browse.retry' | translate"
         (action)="retryRadio()">
       </wavely-empty-state>
     } @else if (radioStations().length === 0) {
       <wavely-empty-state
         icon="radio-outline"
-        title="No stations found"
-        subtitle="No live radio stations available for your country right now."
-        actionLabel="Retry"
+        [title]="'radio.empty_title' | translate"
+        [subtitle]="'radio.empty_subtitle' | translate"
+        [actionLabel]="'browse.retry' | translate"
         (action)="retryRadio()">
       </wavely-empty-state>
     } @else {
@@ -196,7 +196,7 @@
                 @if (station.tags) { · {{ station.tags | slice:0:40 }} }
               </p>
             </ion-label>
-            <ion-badge slot="end" class="radio-item__live-badge" color="danger">LIVE</ion-badge>
+            <ion-badge slot="end" class="radio-item__live-badge" color="danger">{{ 'player.live' | translate }}</ion-badge>
           </ion-item>
         }
       </ion-list>

--- a/src/app/features/browse/browse.page.ts
+++ b/src/app/features/browse/browse.page.ts
@@ -39,6 +39,7 @@ import { CountryService, PODCAST_MARKETS } from '../../core/services/country.ser
 import { RadioApiService, radioStationToEpisode } from '../../core/services/radio-api.service';
 import { RadioStation } from '../../core/models/radio-station.model';
 import { PlayerStore } from '../../store/player/player.store';
+import { TranslatePipe } from '@ngx-translate/core';
 
 // Genre IDs used to populate the three Browse sections with distinct content.
 // Featured → News, New & Noteworthy → Technology, Top → overall chart.
@@ -80,6 +81,7 @@ const CHIP_SKELETON_COUNT = 6;
     SlicePipe,
     PodcastCardComponent,
     EmptyStateComponent,
+    TranslatePipe,
   ],
 })
 export class BrowsePage implements OnDestroy {

--- a/src/app/features/discover/discover.page.html
+++ b/src/app/features/discover/discover.page.html
@@ -1,6 +1,6 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>Discover</ion-title>
+    <ion-title>{{ 'discover.title' | translate }}</ion-title>
     <ion-buttons slot="end">
       <ion-button
         class="country-toggle"
@@ -15,14 +15,14 @@
 <ion-content>
   <div class="search-bar-wrapper">
     <ion-searchbar
-      placeholder="Podcasts, shows, creators…"
+      [placeholder]="'discover.search_placeholder' | translate"
       [value]="searchTerm()"
       [debounce]="0"
       (ionInput)="onSearchInput($event)"
       (ionClear)="onSearchClear()"
       animated
       enterkeyhint="search"
-      aria-label="Search podcasts">
+      [attr.aria-label]="'common.search' | translate">
     </ion-searchbar>
   </div>
 
@@ -52,9 +52,9 @@
     @if (store.error() && !store.isLoading()) {
       <wavely-empty-state
         icon="alert-circle-outline"
-        title="Search failed"
-        [subtitle]="store.error()!"
-        actionLabel="Retry"
+        [title]="'discover.error_title' | translate"
+        [subtitle]="'discover.error_subtitle' | translate"
+        [actionLabel]="'common.retry' | translate"
         (action)="retrySearch()">
       </wavely-empty-state>
     }
@@ -62,8 +62,8 @@
     @if (!store.isLoading() && !store.error() && store.searchResults().length === 0) {
       <wavely-empty-state
         icon="search-outline"
-        title="No podcasts found"
-        [subtitle]="'No results for \'' + searchTerm().trim() + '\' in this region.'">
+        [title]="'discover.no_results_title' | translate"
+        [subtitle]="'discover.no_results_subtitle' | translate">
       </wavely-empty-state>
     }
   } @else {
@@ -91,7 +91,7 @@
     }
 
     <section class="discover-section">
-      <h2 class="section-title">Trending Now</h2>
+      <h2 class="section-title">{{ 'browse.trending_now' | translate }}</h2>
 
       @if (isBrowseLoading()) {
         <div class="podcast-grid" aria-label="Loading trending podcasts">
@@ -118,9 +118,9 @@
       @if (browseError() && !isBrowseLoading()) {
         <wavely-empty-state
           icon="alert-circle-outline"
-          title="Could not load discover"
-          [subtitle]="browseError()!"
-          actionLabel="Retry"
+          [title]="'browse.error_load' | translate"
+          [subtitle]="'browse.error_subtitle' | translate"
+          [actionLabel]="'common.retry' | translate"
           (action)="retryBrowse()">
         </wavely-empty-state>
       }
@@ -128,9 +128,9 @@
       @if (!isBrowseLoading() && !browseError() && topPodcasts().length === 0) {
         <wavely-empty-state
           icon="search-outline"
-          title="No podcasts available"
-          subtitle="Try refreshing or check back later."
-          actionLabel="Refresh"
+          [title]="'browse.no_podcasts' | translate"
+          [subtitle]="'browse.no_podcasts_subtitle' | translate"
+          [actionLabel]="'browse.refresh' | translate"
           (action)="retryBrowse()">
         </wavely-empty-state>
       }
@@ -159,7 +159,7 @@
     </div>
 
     <section class="discover-section">
-      <h2 class="section-title">Top in News</h2>
+      <h2 class="section-title">{{ 'browse.more_in' | translate }} News</h2>
 
       @if (isBrowseLoading()) {
         <div class="podcast-carousel" aria-label="Loading top news podcasts">
@@ -187,7 +187,7 @@
     </section>
 
     <section class="discover-section">
-      <h2 class="section-title">Top in Technology</h2>
+      <h2 class="section-title">{{ 'browse.more_in' | translate }} Technology</h2>
 
       @if (isBrowseLoading()) {
         <div class="podcast-carousel" aria-label="Loading top technology podcasts">

--- a/src/app/features/discover/discover.page.ts
+++ b/src/app/features/discover/discover.page.ts
@@ -60,6 +60,7 @@ import { PodcastCardComponent } from '../../shared/components/podcast-card/podca
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
 import { PODCAST_CATEGORIES } from '../browse/browse.constants';
 import type { PodcastCategory } from '../browse/browse.constants';
+import { TranslatePipe } from '@ngx-translate/core';
 
 const FEATURED_GENRE_ID = 1489;
 const NOTEWORTHY_GENRE_ID = 1318;
@@ -93,6 +94,7 @@ const DEBOUNCE_MS = 300;
     IonIcon,
     PodcastCardComponent,
     EmptyStateComponent,
+    TranslatePipe,
   ],
 })
 export class DiscoverPage implements OnDestroy {

--- a/src/app/features/home/home.page.html
+++ b/src/app/features/home/home.page.html
@@ -1,7 +1,7 @@
 <ion-header>
   <ion-toolbar>
     <ion-title>
-      <span class="header-logo">Wavely</span>
+      <span class="header-logo">{{ 'home.title' | translate }}</span>
     </ion-title>
     <ion-buttons slot="end">
       <ion-button (click)="navigateToSearch()" aria-label="Search podcasts">
@@ -18,7 +18,7 @@
 
   @if (store.subscriptions().length > 0) {
     <section class="home-section">
-      <h2 class="section-title">My Podcasts</h2>
+      <h2 class="section-title">{{ 'home.my_podcasts' | translate }}</h2>
       <div class="subscriptions-scroll">
         <div class="subscriptions-row">
           @for (podcast of store.subscriptions(); track podcast.id) {
@@ -33,9 +33,35 @@
     </section>
   }
 
+  @if (prefs.favoriteStations().length > 0) {
+    <section class="home-section">
+      <h2 class="section-title">{{ 'home.favorite_stations' | translate }}</h2>
+      <div class="subscriptions-scroll">
+        <div class="stations-row">
+          @for (station of prefs.favoriteStations(); track station.stationuuid) {
+            <button
+              type="button"
+              class="station-card"
+              [attr.aria-label]="station.name"
+              (click)="playStation(station)">
+              <div class="station-card__artwork">
+                <img
+                  [src]="station.favicon || '/default-artwork.svg'"
+                  [alt]="station.name"
+                  loading="lazy"
+                  (error)="$any($event.target).src='/default-artwork.svg'" />
+              </div>
+              <p class="station-card__name">{{ station.name }}</p>
+            </button>
+          }
+        </div>
+      </div>
+    </section>
+  }
+
   @if (store.subscriptions().length > 0) {
     <section class="home-section">
-      <h2 class="section-title">Latest Episodes</h2>
+      <h2 class="section-title">{{ 'home.latest_episodes' | translate }}</h2>
 
       @if (isFeedLoading()) {
         <ion-list lines="none" aria-label="Loading latest episodes">
@@ -56,9 +82,9 @@
       @if (feedError() && !isFeedLoading()) {
         <wavely-empty-state
           icon="alert-circle-outline"
-          title="Could not load episodes"
+          [title]="'home.error_feed' | translate"
           [subtitle]="feedError()!"
-          actionLabel="Retry"
+          [actionLabel]="'home.retry' | translate"
           (action)="retryFeed()">
         </wavely-empty-state>
       }
@@ -78,7 +104,7 @@
 
         @if (hasMoreFeed()) {
           <button type="button" class="load-more-btn" (click)="loadMoreFeed()">
-            Load {{ hiddenFeedCount() }} more episodes
+            {{ 'home.load_more' | translate: { count: hiddenFeedCount() } }}
           </button>
         }
       }
@@ -87,15 +113,15 @@
 
   @if (store.subscriptions().length === 0) {
   <section class="home-section">
-    <h2 class="section-title">Trending</h2>
-    <p class="section-subtitle">Discover what's popular and subscribe to personalise your feed.</p>
+    <h2 class="section-title">{{ 'home.trending' | translate }}</h2>
+    <p class="section-subtitle">{{ 'home.trending_subtitle' | translate }}</p>
 
     @if (store.error() && !store.isLoading()) {
       <wavely-empty-state
         icon="alert-circle-outline"
-        title="Could not load trending podcasts"
+        [title]="'home.error_trending' | translate"
         [subtitle]="store.error()!"
-        actionLabel="Retry"
+        [actionLabel]="'home.retry' | translate"
         (action)="retryTrending()">
       </wavely-empty-state>
     }
@@ -127,7 +153,7 @@
         icon="sparkles-outline"
         title="No trending podcasts"
         subtitle="Pull to refresh and try again in a moment."
-        actionLabel="Retry"
+        [actionLabel]="'home.retry' | translate"
         (action)="retryTrending()">
       </wavely-empty-state>
     }

--- a/src/app/features/home/home.page.scss
+++ b/src/app/features/home/home.page.scss
@@ -48,6 +48,52 @@
   width: 120px;
 }
 
+/* Station cards (favorite radio stations) */
+.stations-row {
+  display: flex;
+  gap: 16px;
+  padding-bottom: 8px;
+}
+
+.station-card {
+  flex: 0 0 88px;
+  width: 88px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: center;
+
+  &:active { opacity: 0.7; }
+}
+
+.station-card__artwork {
+  width: 88px;
+  height: 88px;
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--ion-color-light);
+  margin-bottom: 6px;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+}
+
+.station-card__name {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--wavely-on-surface);
+  line-height: 1.3;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
 /* Header */
 .header-logo {
   font-size: 20px;

--- a/src/app/features/home/home.page.ts
+++ b/src/app/features/home/home.page.ts
@@ -31,6 +31,7 @@ import {
   searchOutline,
   sparklesOutline,
   chevronDownOutline,
+  radioOutline,
 } from 'ionicons/icons';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
 import { PodcastsStore } from '../../store/podcasts/podcasts.store';
@@ -39,8 +40,11 @@ import { PlayerStore } from '../../store/player/player.store';
 import { HistoryStore } from '../../store/history/history.store';
 import { PodcastCardComponent } from '../../shared/components/podcast-card/podcast-card.component';
 import { Episode, Podcast } from '../../core/models/podcast.model';
+import { RadioStation } from '../../core/models/radio-station.model';
+import { radioStationToEpisode } from '../../core/services/radio-api.service';
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
 import { EpisodeItemComponent } from '../../shared/components/episode-item/episode-item.component';
+import { TranslatePipe } from '@ngx-translate/core';
 
 const SKELETON_COUNT = 6;
 const FEED_LIMIT_PER_PODCAST = 20;
@@ -71,6 +75,7 @@ const FEED_MAX_AGE_DAYS = 30;
     PodcastCardComponent,
     EmptyStateComponent,
     EpisodeItemComponent,
+    TranslatePipe,
   ],
 })
 export class HomePage implements OnInit {
@@ -81,7 +86,7 @@ export class HomePage implements OnInit {
   private readonly countryService = inject(CountryService);
   private readonly playerStore = inject(PlayerStore);
   private readonly historyStore = inject(HistoryStore);
-  private readonly prefs = inject(UserPreferencesService);
+  protected readonly prefs = inject(UserPreferencesService);
 
   protected readonly skeletons = Array.from({ length: SKELETON_COUNT });
   protected readonly feedSkeletons = Array.from({ length: 5 });
@@ -128,6 +133,7 @@ export class HomePage implements OnInit {
       alertCircleOutline,
       sparklesOutline,
       chevronDownOutline,
+      radioOutline,
     });
 
     // Reload feed whenever the set of subscriptions changes (handles new subscriptions added later)
@@ -196,6 +202,11 @@ export class HomePage implements OnInit {
 
   protected queueEpisode(episode: Episode): void {
     this.playerStore.addToQueue(episode);
+  }
+
+  protected playStation(station: RadioStation): void {
+    this.playerStore.play(radioStationToEpisode(station));
+    void this.playerModal.open();
   }
 
   private loadTrending(): Promise<void> {

--- a/src/app/features/library/library.page.html
+++ b/src/app/features/library/library.page.html
@@ -1,6 +1,6 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>Library</ion-title>
+    <ion-title>{{ 'library.title' | translate }}</ion-title>
     <ion-buttons slot="end">
       @if (authStore.isAuthenticated()) {
         <ion-button id="profile-popover-trigger" [attr.aria-label]="'Account: ' + (authStore.displayName() ?? 'Profile')">
@@ -21,11 +21,11 @@
               </ion-item>
               <ion-item button (click)="navigateToSettings()" lines="none">
                 <ion-icon name="settings-outline" slot="start"></ion-icon>
-                <ion-label>Settings</ion-label>
+                <ion-label>{{ 'library.settings' | translate }}</ion-label>
               </ion-item>
               <ion-item button (click)="signOut()" lines="none">
                 <ion-icon name="log-out-outline" slot="start" color="danger"></ion-icon>
-                <ion-label color="danger">Sign out</ion-label>
+                <ion-label color="danger">{{ 'library.sign_out' | translate }}</ion-label>
               </ion-item>
               <ion-item lines="none" class="version-item">
                 <ion-label class="version-label">v{{ appVersion }}</ion-label>
@@ -34,7 +34,7 @@
           </ng-template>
         </ion-popover>
       }
-      <ion-button (click)="navigateToBrowse()" aria-label="Add podcasts">
+      <ion-button (click)="navigateToBrowse()" [attr.aria-label]="'library.browse_podcasts' | translate">
         <ion-icon slot="icon-only" name="add-outline"></ion-icon>
       </ion-button>
     </ion-buttons>
@@ -44,8 +44,8 @@
 <ion-content>
   <section class="library-section">
     <div class="section-header">
-      <h2 class="section-title">Continue Listening</h2>
-      <ion-button fill="clear" size="small" class="clear-history-btn" (click)="clearHistory()">Clear</ion-button>
+      <h2 class="section-title">{{ 'library.continue_listening' | translate }}</h2>
+      <ion-button fill="clear" size="small" class="clear-history-btn" (click)="clearHistory()">{{ 'library.clear' | translate }}</ion-button>
     </div>
 
     <div class="history-filters" role="tablist" aria-label="History filters">
@@ -55,16 +55,16 @@
           [class.active]="historyStore.activeFilter() === filter.value"
           [outline]="historyStore.activeFilter() !== filter.value"
           (click)="selectFilter(filter.value)">
-          <ion-label>{{ filter.label }}</ion-label>
+          <ion-label>{{ filter.label | translate }}</ion-label>
         </ion-chip>
       }
     </div>
 
     @if (recentHistory().length === 0) {
       @if (historyStore.activeFilter() === 'all') {
-        <wavely-empty-state icon="time-outline" title="Nothing in progress" subtitle="Start an episode and it will appear here to continue."></wavely-empty-state>
+        <wavely-empty-state icon="time-outline" [title]="'library.empty_history_progress_title' | translate" [subtitle]="'library.empty_history_progress_subtitle' | translate"></wavely-empty-state>
       } @else {
-        <wavely-empty-state icon="time-outline" title="No episodes here" subtitle="Try a different filter."></wavely-empty-state>
+        <wavely-empty-state icon="time-outline" [title]="'library.empty_history_filter_title' | translate" [subtitle]="'library.empty_history_filter_subtitle' | translate"></wavely-empty-state>
       }
     } @else {
       <p class="list-hint">Swipe left or tap <ion-icon name="checkmark-circle-outline" style="vertical-align: middle"></ion-icon> to mark played</p>
@@ -112,18 +112,18 @@
 
       @if (hiddenCount() > 0) {
         <button type="button" class="show-all-btn" (click)="toggleShowAll()">
-          Show {{ hiddenCount() }} more episodes
+          {{ 'library.show_all' | translate }} ({{ hiddenCount() }})
         </button>
       } @else if (showAllHistory()) {
         <button type="button" class="show-all-btn" (click)="toggleShowAll()">
-          Show less
+          {{ 'library.show_less' | translate }}
         </button>
       }
     }
   </section>
 
   <section class="library-section">
-    <h2 class="section-title">Subscriptions</h2>
+    <h2 class="section-title">{{ 'library.subscriptions' | translate }}</h2>
     @if (store.subscriptions().length > 0) {
       <p class="list-hint">Swipe left to unsubscribe</p>
       <ion-list lines="full">
@@ -140,31 +140,14 @@
               <ion-button slot="end" fill="clear" color="medium" size="small" [attr.aria-label]="'Unsubscribe from ' + podcast.title" (click)="$event.stopPropagation(); unsubscribe(podcast, slidingItem)">✕</ion-button>
             </ion-item>
             <ion-item-options side="end">
-              <ion-item-option color="danger" (click)="unsubscribe(podcast, slidingItem)">Unsubscribe</ion-item-option>
+              <ion-item-option color="danger" (click)="unsubscribe(podcast, slidingItem)">{{ 'library.unsubscribe' | translate }}</ion-item-option>
             </ion-item-options>
           </ion-item-sliding>
         }
       </ion-list>
     } @else {
-      <wavely-empty-state icon="library-outline" title="No subscriptions yet" subtitle="Browse podcasts and subscribe to build your library." actionLabel="Browse Podcasts" (action)="navigateToBrowse()"></wavely-empty-state>
+      <wavely-empty-state icon="library-outline" [title]="'library.empty_subscriptions_title' | translate" [subtitle]="'library.empty_subscriptions_subtitle' | translate" [actionLabel]="'library.browse_podcasts' | translate" (action)="navigateToBrowse()"></wavely-empty-state>
     }
   </section>
 
-  <section class="library-section">
-    <h2 class="section-title">Preferences</h2>
-    <ion-list lines="none">
-      <ion-item>
-        <ion-label>
-          <h3>Auto-queue episodes</h3>
-          <p>Automatically add remaining episodes to Up Next when you start playing</p>
-        </ion-label>
-        <ion-toggle
-          slot="end"
-          [checked]="prefs.autoQueueEnabled()"
-          (ionChange)="onAutoQueueChange($event)"
-          aria-label="Auto-queue episodes">
-        </ion-toggle>
-      </ion-item>
-    </ion-list>
-  </section>
 </ion-content>

--- a/src/app/features/library/library.page.ts
+++ b/src/app/features/library/library.page.ts
@@ -21,7 +21,6 @@ import {
   IonThumbnail,
   IonProgressBar,
   IonChip,
-  IonToggle,
 } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import {
@@ -39,11 +38,11 @@ import { AuthStore } from '../../store/auth/auth.store';
 import { HistoryStore, HistoryEntry, HistoryFilter } from '../../store/history/history.store';
 import { SubscriptionSyncService } from '../../core/services/subscription-sync.service';
 import { HistorySyncService } from '../../core/services/history-sync.service';
-import { UserPreferencesService } from '../../core/services/user-preferences.service';
 import { Podcast } from '../../core/models/podcast.model';
 
 import { environment } from '../../../environments/environment';
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   selector: 'wavely-library',
@@ -70,15 +69,14 @@ import { EmptyStateComponent } from '../../shared/components/empty-state/empty-s
     IonThumbnail,
     IonProgressBar,
     IonChip,
-    IonToggle,
     EmptyStateComponent,
+    TranslatePipe,
   ],
 })
 export class LibraryPage {
   protected readonly store = inject(PodcastsStore);
   protected readonly authStore = inject(AuthStore);
   protected readonly historyStore = inject(HistoryStore);
-  protected readonly prefs = inject(UserPreferencesService);
   protected readonly appVersion = environment.appVersion;
   private readonly syncService = inject(SubscriptionSyncService);
   private readonly historySyncService = inject(HistorySyncService);
@@ -106,10 +104,10 @@ export class LibraryPage {
   });
 
   protected readonly historyFilters: { label: string; value: HistoryFilter }[] = [
-    { label: 'All', value: 'all' },
-    { label: 'Unplayed', value: 'unplayed' },
-    { label: 'In Progress', value: 'inProgress' },
-    { label: 'Completed', value: 'completed' },
+    { label: 'library.filter_all', value: 'all' },
+    { label: 'library.filter_unplayed', value: 'unplayed' },
+    { label: 'library.filter_in_progress', value: 'inProgress' },
+    { label: 'library.filter_completed', value: 'completed' },
   ];
 
 
@@ -223,10 +221,6 @@ export class LibraryPage {
   protected async signOut(): Promise<void> {
     await this.authStore.signOut();
     this.router.navigate(['/login']);
-  }
-
-  protected onAutoQueueChange(event: CustomEvent<{ checked: boolean }>): void {
-    this.prefs.setAutoQueueEnabled(event.detail.checked);
   }
 
   protected onImageError(event: Event): void {

--- a/src/app/features/player/full-player/full-player.component.html
+++ b/src/app/features/player/full-player/full-player.component.html
@@ -1,7 +1,7 @@
 <ion-header class="full-player__header ion-no-border">
   <ion-toolbar>
     <ion-buttons slot="start">
-      <ion-button fill="clear" (click)="dismiss()" aria-label="Collapse player">
+      <ion-button fill="clear" (click)="dismiss()" [attr.aria-label]="'player.close' | translate">
         <ion-icon slot="icon-only" name="chevron-down"></ion-icon>
       </ion-button>
     </ion-buttons>
@@ -10,7 +10,7 @@
 
     <ion-buttons slot="end">
       @if (!isLive) {
-        <ion-button fill="clear" (click)="showSpeedPicker()" [attr.aria-label]="'Playback speed: ' + rateLabel">
+        <ion-button fill="clear" (click)="showSpeedPicker()" [attr.aria-label]="('player.playback_rate' | translate) + ': ' + rateLabel">
           <span class="full-player__rate-badge">{{ rateLabel }}</span>
         </ion-button>
       }
@@ -32,7 +32,7 @@
       <div class="full-player__info">
         <h2 class="full-player__title">{{ store.currentEpisode()!.title }}</h2>
         @if (isLive) {
-          <span class="full-player__live-badge" aria-label="Live stream">● LIVE</span>
+          <span class="full-player__live-badge" [attr.aria-label]="'player.live' | translate">● {{ 'player.live' | translate }}</span>
         }
       </div>
       <!-- Scrubber (hidden for live streams) -->
@@ -57,7 +57,7 @@
       <!-- Controls -->
       <div class="full-player__controls">
         @if (!isLive) {
-          <button class="full-player__skip-btn" (click)="skipBack()" aria-label="Skip back 15 seconds">
+          <button class="full-player__skip-btn" (click)="skipBack()" [attr.aria-label]="'player.skip_back' | translate">
             <ion-icon name="play-skip-back"></ion-icon>
             <span class="full-player__skip-label">15</span>
           </button>
@@ -65,11 +65,11 @@
         <button
           class="full-player__play-pause-btn"
           (click)="togglePlay()"
-          [attr.aria-label]="store.isPlaying() ? 'Pause' : 'Play'">
+          [attr.aria-label]="store.isPlaying() ? ('player.pause' | translate) : ('player.play' | translate)">
           <ion-icon [name]="store.isPlaying() ? 'pause-circle' : 'play-circle'"></ion-icon>
         </button>
         @if (!isLive) {
-          <button class="full-player__skip-btn" (click)="skipForward()" aria-label="Skip forward 30 seconds">
+          <button class="full-player__skip-btn" (click)="skipForward()" [attr.aria-label]="'player.skip_forward' | translate">
             <ion-icon name="play-skip-forward"></ion-icon>
             <span class="full-player__skip-label">30</span>
           </button>
@@ -81,9 +81,9 @@
         <div class="full-player__queue">
           <div class="full-player__queue-header">
             <ion-icon name="list-outline" class="full-player__queue-icon"></ion-icon>
-            <span class="full-player__queue-title">Up Next</span>
+            <span class="full-player__queue-title">{{ 'player.up_next' | translate }}</span>
             <button class="full-player__queue-clear" (click)="store.clearQueue()" aria-label="Clear queue">
-              Clear
+              {{ 'library.clear' | translate }}
             </button>
           </div>
           <ion-list lines="none" class="full-player__queue-list">

--- a/src/app/features/player/full-player/full-player.component.spec.ts
+++ b/src/app/features/player/full-player/full-player.component.spec.ts
@@ -10,11 +10,16 @@ jest.mock('@angular/fire/auth', () => ({
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { FullPlayerComponent } from './full-player.component';
 import { PlayerStore } from '../../../store/player/player.store';
 import { ModalController, ActionSheetController } from '@ionic/angular/standalone';
 import { mockPlayerStore } from '../../../../testing/mock-stores';
 import { mockEpisode } from '../../../../testing/podcast-fixtures';
+import {
+  loadTranslations,
+  provideTranslateTesting,
+} from '../../../../testing/translate-testing.helper';
 
 describe('FullPlayerComponent', () => {
   let component: FullPlayerComponent;
@@ -36,10 +41,12 @@ describe('FullPlayerComponent', () => {
         { provide: PlayerStore, useValue: store },
         { provide: ModalController, useValue: mockModalCtrl },
         { provide: ActionSheetController, useValue: mockActionSheetCtrl },
+        ...provideTranslateTesting(),
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
+    loadTranslations(TestBed.inject(TranslateService));
     fixture = TestBed.createComponent(FullPlayerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/features/player/full-player/full-player.component.ts
+++ b/src/app/features/player/full-player/full-player.component.ts
@@ -29,6 +29,7 @@ import {
 import { PlayerStore } from '../../../store/player/player.store';
 import { AudioService } from '../../../core/services/audio.service';
 import { RangeCustomEvent } from '@ionic/angular';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   selector: 'wavely-full-player',
@@ -46,6 +47,7 @@ import { RangeCustomEvent } from '@ionic/angular';
     IonItem,
     IonLabel,
     IonNote,
+    TranslatePipe,
   ],
 })
 export class FullPlayerComponent {

--- a/src/app/features/player/mini-player/mini-player.component.html
+++ b/src/app/features/player/mini-player/mini-player.component.html
@@ -25,7 +25,7 @@
         fill="clear"
         class="mini-player__play-btn"
         (click)="togglePlay($event)"
-        [attr.aria-label]="store.isPlaying() ? 'Pause' : 'Play'">
+        [attr.aria-label]="store.isPlaying() ? ('player.pause' | translate) : ('player.play' | translate)">
         <ion-icon
           slot="icon-only"
           [name]="store.isPlaying() ? 'pause-circle' : 'play-circle'">
@@ -35,7 +35,7 @@
         fill="clear"
         class="mini-player__close-btn"
         (click)="close($event)"
-        aria-label="Close player">
+        [attr.aria-label]="'player.close' | translate">
         <ion-icon slot="icon-only" name="close-circle"></ion-icon>
       </ion-button>
     </div>

--- a/src/app/features/player/mini-player/mini-player.component.spec.ts
+++ b/src/app/features/player/mini-player/mini-player.component.spec.ts
@@ -1,9 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
 import { MiniPlayerComponent } from './mini-player.component';
 import { PlayerStore } from '../../../store/player/player.store';
 import { mockPlayerStore } from '../../../../testing/mock-stores';
 import { mockEpisode } from '../../../../testing/podcast-fixtures';
+import {
+  loadTranslations,
+  provideTranslateTesting,
+} from '../../../../testing/translate-testing.helper';
 
 describe('MiniPlayerComponent', () => {
   let component: MiniPlayerComponent;
@@ -15,10 +20,14 @@ describe('MiniPlayerComponent', () => {
 
     TestBed.configureTestingModule({
       imports: [MiniPlayerComponent],
-      providers: [{ provide: PlayerStore, useValue: store }],
+      providers: [
+        { provide: PlayerStore, useValue: store },
+        ...provideTranslateTesting(),
+      ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
+    loadTranslations(TestBed.inject(TranslateService));
     fixture = TestBed.createComponent(MiniPlayerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/features/player/mini-player/mini-player.component.ts
+++ b/src/app/features/player/mini-player/mini-player.component.ts
@@ -9,12 +9,13 @@ import {
 import { addIcons } from 'ionicons';
 import { playCircle, pauseCircle, closeCircle } from 'ionicons/icons';
 import { PlayerStore } from '../../../store/player/player.store';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   selector: 'wavely-mini-player',
   templateUrl: './mini-player.component.html',
   styleUrls: ['./mini-player.component.scss'],
-  imports: [IonThumbnail, IonButton, IonIcon, IonProgressBar],
+  imports: [IonThumbnail, IonButton, IonIcon, IonProgressBar, TranslatePipe],
 })
 export class MiniPlayerComponent {
   readonly store = inject(PlayerStore);

--- a/src/app/features/podcast-detail/podcast-detail.page.html
+++ b/src/app/features/podcast-detail/podcast-detail.page.html
@@ -33,10 +33,10 @@
   <!-- Error: podcast metadata failed -->
   @if (podcastError && !isLoading) {
     <div class="state-message">
-      <ion-text color="medium"><p>{{ podcastError }}</p></ion-text>
+      <ion-text color="medium"><p>{{ 'podcast_detail.error_title' | translate }}</p></ion-text>
       <ion-button fill="outline" size="small" (click)="retryLoad()">
         <ion-icon name="refresh-outline" slot="start"></ion-icon>
-        Retry
+        {{ 'podcast_detail.retry' | translate }}
       </ion-button>
     </div>
   }
@@ -63,7 +63,7 @@
         }
         @if (podcast.episodeCount) {
           <p class="podcast-count">
-            {{ podcast.episodeCount }} episodes
+            {{ podcast.episodeCount }} {{ 'podcast_detail.episodes' | translate }}
           </p>
         }
         <ion-button
@@ -71,28 +71,29 @@
           [color]="isSubscribed ? 'primary' : 'medium'"
           size="small"
           shape="round"
+          [attr.aria-label]="isSubscribed ? ('podcast_detail.subscribed' | translate) : ('podcast_detail.subscribe' | translate)"
           (click)="toggleSubscription()">
           <ion-icon
             slot="start"
             [name]="isSubscribed ? 'checkmark-circle' : 'add-circle-outline'">
           </ion-icon>
-          {{ isSubscribed ? 'Subscribed' : 'Subscribe' }}
+          {{ isSubscribed ? ('podcast_detail.subscribed' | translate) : ('podcast_detail.subscribe' | translate) }}
         </ion-button>
       </div>
     </div>
     <!-- Episodes error (episodes can fail independently) -->
     @if (episodesError) {
       <div class="state-message">
-        <ion-text color="medium"><p>{{ episodesError }}</p></ion-text>
+        <ion-text color="medium"><p>{{ 'podcast_detail.error_subtitle' | translate }}</p></ion-text>
         <ion-button fill="outline" size="small" (click)="retryLoad()">
           <ion-icon name="refresh-outline" slot="start"></ion-icon>
-          Retry
+          {{ 'podcast_detail.retry' | translate }}
         </ion-button>
       </div>
     }
     <!-- Episodes -->
     @if (episodes.length > 0) {
-      <h2 class="section-title">Episodes</h2>
+      <h2 class="section-title">{{ 'podcast_detail.episodes' | translate }}</h2>
     }
     @if (episodes.length > 0) {
       <ion-list lines="none">
@@ -107,12 +108,12 @@
       </ion-list>
 
       <ion-infinite-scroll [disabled]="!hasMoreEpisodes" (ionInfinite)="loadMoreEpisodes($event)">
-        <ion-infinite-scroll-content loadingText="Loading more episodes…"></ion-infinite-scroll-content>
+        <ion-infinite-scroll-content [loadingText]="'common.loading' | translate"></ion-infinite-scroll-content>
       </ion-infinite-scroll>
     }
     @if (episodes.length === 0 && !episodesError) {
       <div class="state-message">
-        <ion-text color="medium"><p>No episodes available.</p></ion-text>
+        <ion-text color="medium"><p>{{ 'podcast_detail.no_episodes_title' | translate }}</p></ion-text>
       </div>
     }
   }

--- a/src/app/features/podcast-detail/podcast-detail.page.spec.ts
+++ b/src/app/features/podcast-detail/podcast-detail.page.spec.ts
@@ -12,6 +12,7 @@ import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { of, throwError } from 'rxjs';
+import { TranslateService, TranslatePipe } from '@ngx-translate/core';
 
 import { PodcastDetailPage } from './podcast-detail.page';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
@@ -27,6 +28,10 @@ import {
   mockPodcastsStore as createMockPodcastsStore,
   mockAuthStore,
 } from '../../../testing/mock-stores';
+import {
+  loadTranslations,
+  provideTranslateTesting,
+} from '../../../testing/translate-testing.helper';
 
 describe('PodcastDetailPage', () => {
   let fixture: ComponentFixture<PodcastDetailPage>;
@@ -63,14 +68,16 @@ describe('PodcastDetailPage', () => {
         { provide: SubscriptionSyncService, useValue: mockSyncService },
         { provide: Router, useValue: mockRouter },
         { provide: PlayerModalService, useValue: { open: jest.fn().mockResolvedValue(undefined) } },
+        ...provideTranslateTesting(),
       ],
       schemas: [NO_ERRORS_SCHEMA],
     })
       .overrideComponent(PodcastDetailPage, {
-        set: { imports: [DatePipe], schemas: [NO_ERRORS_SCHEMA] },
+        set: { imports: [DatePipe, TranslatePipe], schemas: [NO_ERRORS_SCHEMA] },
       })
       .compileComponents();
 
+    loadTranslations(TestBed.inject(TranslateService));
     fixture = TestBed.createComponent(PodcastDetailPage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/features/podcast-detail/podcast-detail.page.ts
+++ b/src/app/features/podcast-detail/podcast-detail.page.ts
@@ -33,6 +33,7 @@ import { Observable, catchError, of, retry } from 'rxjs';
 import { EpisodeItemComponent } from '../../shared/components/episode-item/episode-item.component';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { map, switchMap } from 'rxjs/operators';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   selector: 'wavely-podcast-detail',
@@ -56,6 +57,7 @@ import { map, switchMap } from 'rxjs/operators';
     IonInfiniteScroll,
     IonInfiniteScrollContent,
     EpisodeItemComponent,
+    TranslatePipe,
   ],
 })
 export class PodcastDetailPage {

--- a/src/app/features/publisher/publisher.page.html
+++ b/src/app/features/publisher/publisher.page.html
@@ -3,7 +3,7 @@
     <ion-buttons slot="start">
       <ion-back-button defaultHref="/tabs/home"></ion-back-button>
     </ion-buttons>
-    <ion-title>{{ publisherName() }}</ion-title>
+    <ion-title>{{ publisherName() || ('publisher.title' | translate) }}</ion-title>
   </ion-toolbar>
 </ion-header>
 
@@ -25,9 +25,9 @@
   @if (error() && !isLoading()) {
     <wavely-empty-state
       icon="alert-circle-outline"
-      title="Could not load this publisher"
-      [subtitle]="error()!"
-      actionLabel="Retry"
+      [title]="'publisher.error_title' | translate"
+      [subtitle]="'publisher.error_subtitle' | translate"
+      [actionLabel]="'publisher.retry' | translate"
       (action)="retry()">
     </wavely-empty-state>
   }
@@ -52,9 +52,9 @@
   @if (!isLoading() && !error() && visiblePodcasts().length === 0) {
     <wavely-empty-state
       icon="search-outline"
-      title="No podcasts found"
-      subtitle="This publisher has no podcasts in the iTunes catalogue."
-      actionLabel="Refresh"
+      [title]="'discover.no_results_title' | translate"
+      [subtitle]="'discover.no_results_subtitle' | translate"
+      [actionLabel]="'browse.refresh' | translate"
       (action)="retry()">
     </wavely-empty-state>
   }

--- a/src/app/features/publisher/publisher.page.ts
+++ b/src/app/features/publisher/publisher.page.ts
@@ -28,6 +28,7 @@ import { Podcast } from '../../core/models/podcast.model';
 import { PodcastApiService } from '../../core/services/podcast-api.service';
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
 import { PodcastCardComponent } from '../../shared/components/podcast-card/podcast-card.component';
+import { TranslatePipe } from '@ngx-translate/core';
 
 const SKELETON_COUNT = 6;
 const PAGE_SIZE = 12;
@@ -51,6 +52,7 @@ const PAGE_SIZE = 12;
     IonToolbar,
     PodcastCardComponent,
     EmptyStateComponent,
+    TranslatePipe,
   ],
 })
 export class PublisherPage {

--- a/src/app/features/radio/radio.page.html
+++ b/src/app/features/radio/radio.page.html
@@ -1,6 +1,6 @@
 <ion-header>
   <ion-toolbar>
-    <ion-title>Radio</ion-title>
+    <ion-title>{{ 'radio.title' | translate }}</ion-title>
     <ion-buttons slot="end">
       <ion-button
         class="country-toggle"
@@ -15,14 +15,14 @@
 <ion-content>
   <div class="search-bar-wrapper">
     <ion-searchbar
-      placeholder="Search stations worldwide…"
+      [placeholder]="'discover.search_placeholder' | translate"
       [value]="searchQuery()"
       [debounce]="0"
       (ionInput)="onSearchInput($event)"
       (ionClear)="onSearchClear()"
       animated
       enterkeyhint="search"
-      aria-label="Search radio stations">
+      [attr.aria-label]="'common.search' | translate">
     </ion-searchbar>
   </div>
 
@@ -55,17 +55,17 @@
   } @else if (error()) {
     <wavely-empty-state
       icon="alert-circle-outline"
-      [title]="isSearchMode() ? 'Search failed' : 'Could not load radio'"
-      [subtitle]="error()!"
-      actionLabel="Retry"
+      [title]="'radio.error_title' | translate"
+      [subtitle]="'radio.error_subtitle' | translate"
+      [actionLabel]="'radio.retry' | translate"
       (action)="retry()">
     </wavely-empty-state>
   } @else if (filteredStations().length === 0) {
     <wavely-empty-state
       [icon]="isSearchMode() ? 'search-outline' : 'radio-outline'"
-      [title]="isSearchMode() ? 'No stations found' : 'No stations available'"
-      [subtitle]="isSearchMode() ? 'Try a different name or keyword.' : 'No live radio stations available with your current filters.'"
-      [actionLabel]="isSearchMode() ? '' : 'Retry'"
+      [title]="'radio.empty_title' | translate"
+      [subtitle]="'radio.empty_subtitle' | translate"
+      [actionLabel]="isSearchMode() ? '' : ('radio.retry' | translate)"
       (action)="retry()">
     </wavely-empty-state>
   } @else {
@@ -77,7 +77,7 @@
             <ion-item
               button
               class="radio-item"
-              [attr.aria-label]="'Play ' + station.name + ' live'"
+              [attr.aria-label]="('player.play_stream' | translate) + ': ' + station.name"
               (click)="playStation(station)">
               <ion-thumbnail slot="start" class="radio-item__thumbnail">
                 <img
@@ -93,7 +93,7 @@
                   @if (station.tags) { · {{ station.tags | slice:0:40 }} }
                 </p>
               </ion-label>
-              <ion-badge slot="end" class="radio-item__live-badge" color="danger">LIVE</ion-badge>
+              <ion-badge slot="end" class="radio-item__live-badge" color="danger">{{ 'player.live' | translate }}</ion-badge>
               <ion-button
                 slot="end"
                 fill="clear"
@@ -125,7 +125,7 @@
         <ion-item
           button
           class="radio-item"
-          [attr.aria-label]="'Play ' + station.name + ' live'"
+          [attr.aria-label]="('player.play_stream' | translate) + ': ' + station.name"
           (click)="playStation(station)">
           <ion-thumbnail slot="start" class="radio-item__thumbnail">
             <img
@@ -142,7 +142,7 @@
               @if (isSearchMode() && station.countrycode) { · {{ station.countrycode.toUpperCase() }} }
             </p>
           </ion-label>
-          <ion-badge slot="end" class="radio-item__live-badge" color="danger">LIVE</ion-badge>
+          <ion-badge slot="end" class="radio-item__live-badge" color="danger">{{ 'player.live' | translate }}</ion-badge>
           <ion-button
             slot="end"
             fill="clear"

--- a/src/app/features/radio/radio.page.ts
+++ b/src/app/features/radio/radio.page.ts
@@ -29,6 +29,7 @@ import { RadioApiService, radioStationToEpisode } from '../../core/services/radi
 import { UserPreferencesService } from '../../core/services/user-preferences.service';
 import { PlayerStore } from '../../store/player/player.store';
 import { EmptyStateComponent } from '../../shared/components/empty-state/empty-state.component';
+import { TranslatePipe } from '@ngx-translate/core';
 
 const SKELETON_COUNT = 8;
 const MAX_TAG_CHIPS = 14;
@@ -59,6 +60,7 @@ const SEARCH_LIMIT = 60;
     IonSkeletonText,
     SlicePipe,
     EmptyStateComponent,
+    TranslatePipe,
   ],
 })
 export class RadioPage implements OnDestroy {
@@ -121,7 +123,7 @@ export class RadioPage implements OnDestroy {
 
   protected readonly favoriteStations = computed(() => {
     if (this.isSearchMode()) return [];
-    return this.stations().filter((station) => this.prefs.isFavorite(station.stationuuid));
+    return this.prefs.favoriteStations();
   });
 
   private readonly country$ = new Subject<string>();
@@ -152,6 +154,7 @@ export class RadioPage implements OnDestroy {
       .subscribe((stations) => {
         this.stations.set(stations);
         this.isLoading.set(false);
+        this.prefs.migrateLegacyFavorites(stations);
       });
 
     this.search$
@@ -218,7 +221,7 @@ export class RadioPage implements OnDestroy {
 
   protected onToggleFavorite(station: RadioStation, event: Event): void {
     event.stopPropagation();
-    this.prefs.toggleFavorite(station.stationuuid);
+    this.prefs.toggleFavorite(station);
   }
 
   protected isStationFavorite(stationuuid: string): boolean {

--- a/src/app/features/settings/settings.page.html
+++ b/src/app/features/settings/settings.page.html
@@ -3,19 +3,19 @@
     <ion-buttons slot="start">
       <ion-back-button defaultHref="/tabs/library"></ion-back-button>
     </ion-buttons>
-    <ion-title>Settings</ion-title>
+    <ion-title>{{ 'settings.title' | translate }}</ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content>
 
   <ion-list>
-    <ion-list-header>Appearance</ion-list-header>
+    <ion-list-header>{{ 'settings.appearance' | translate }}</ion-list-header>
     <ion-radio-group [value]="themeService.mode()" (ionChange)="themeService.setMode($any($event).detail.value)">
       @for (opt of themeOptions; track opt.value) {
         <ion-item>
           <ion-icon [name]="opt.icon" slot="start" aria-hidden="true"></ion-icon>
-          <ion-label>{{ opt.label }}</ion-label>
+          <ion-label>{{ opt.labelKey | translate }}</ion-label>
           <ion-radio slot="end" [value]="opt.value"></ion-radio>
         </ion-item>
       }
@@ -23,12 +23,12 @@
   </ion-list>
 
   <ion-list>
-    <ion-list-header>Playback</ion-list-header>
+    <ion-list-header>{{ 'settings.playback' | translate }}</ion-list-header>
     <ion-item>
       <ion-icon name="list-outline" slot="start" aria-hidden="true"></ion-icon>
       <ion-label>
-        <h3>Auto-queue</h3>
-        <ion-note>Automatically queue remaining episodes when you play one</ion-note>
+        <h3>{{ 'settings.auto_queue' | translate }}</h3>
+        <ion-note>{{ 'settings.auto_queue_note' | translate }}</ion-note>
       </ion-label>
       <ion-toggle
         slot="end"
@@ -39,9 +39,29 @@
   </ion-list>
 
   <ion-list>
-    <ion-list-header>About</ion-list-header>
+    <ion-list-header>{{ 'settings.language' | translate }}</ion-list-header>
+    <ion-item>
+      <ion-icon name="language-outline" slot="start" aria-hidden="true"></ion-icon>
+      <ion-label>
+        <h3>{{ 'settings.language' | translate }}</h3>
+        <ion-note>{{ 'settings.language_note' | translate }}</ion-note>
+      </ion-label>
+      <ion-select
+        slot="end"
+        [value]="languageService.current()"
+        (ionChange)="onLanguageChange($any($event))"
+        interface="popover">
+        @for (lang of languageService.supported; track lang.code) {
+          <ion-select-option [value]="lang.code">{{ lang.label }}</ion-select-option>
+        }
+      </ion-select>
+    </ion-item>
+  </ion-list>
+
+  <ion-list>
+    <ion-list-header>{{ 'settings.about' | translate }}</ion-list-header>
     <ion-item lines="none">
-      <ion-label>Version</ion-label>
+      <ion-label>{{ 'settings.version' | translate }}</ion-label>
       <ion-note slot="end">v{{ appVersion }}</ion-note>
     </ion-item>
   </ion-list>

--- a/src/app/features/settings/settings.page.ts
+++ b/src/app/features/settings/settings.page.ts
@@ -2,14 +2,16 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import {
   IonHeader, IonToolbar, IonTitle, IonContent, IonList, IonItem,
   IonLabel, IonListHeader, IonRadioGroup, IonRadio, IonToggle,
-  IonIcon, IonButtons, IonBackButton, IonNote,
+  IonIcon, IonButtons, IonBackButton, IonNote, IonSelect, IonSelectOption,
 } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import {
-  sunnyOutline, moonOutline, contrastOutline, listOutline,
+  sunnyOutline, moonOutline, contrastOutline, listOutline, languageOutline,
 } from 'ionicons/icons';
+import { TranslatePipe } from '@ngx-translate/core';
 import { ThemeService, ThemeMode } from '../../core/services/theme.service';
 import { UserPreferencesService } from '../../core/services/user-preferences.service';
+import { LanguageService } from '../../core/services/language.service';
 import { environment } from '../../../environments/environment';
 
 @Component({
@@ -20,25 +22,31 @@ import { environment } from '../../../environments/environment';
   imports: [
     IonHeader, IonToolbar, IonTitle, IonContent, IonList, IonItem,
     IonLabel, IonListHeader, IonRadioGroup, IonRadio, IonToggle,
-    IonIcon, IonButtons, IonBackButton, IonNote,
+    IonIcon, IonButtons, IonBackButton, IonNote, IonSelect, IonSelectOption,
+    TranslatePipe,
   ],
 })
 export class SettingsPage {
   protected readonly themeService = inject(ThemeService);
   protected readonly prefs = inject(UserPreferencesService);
+  protected readonly languageService = inject(LanguageService);
   protected readonly appVersion = environment.appVersion;
 
-  protected readonly themeOptions: { label: string; value: ThemeMode; icon: string }[] = [
-    { label: 'System default', value: 'system', icon: 'contrast-outline' },
-    { label: 'Light', value: 'light', icon: 'sunny-outline' },
-    { label: 'Dark', value: 'dark', icon: 'moon-outline' },
+  protected readonly themeOptions: { labelKey: string; value: ThemeMode; icon: string }[] = [
+    { labelKey: 'settings.theme_system', value: 'system', icon: 'contrast-outline' },
+    { labelKey: 'settings.theme_light', value: 'light', icon: 'sunny-outline' },
+    { labelKey: 'settings.theme_dark', value: 'dark', icon: 'moon-outline' },
   ];
 
   constructor() {
-    addIcons({ sunnyOutline, moonOutline, contrastOutline, listOutline });
+    addIcons({ sunnyOutline, moonOutline, contrastOutline, listOutline, languageOutline });
   }
 
   onAutoQueueChange(event: CustomEvent<{ checked: boolean }>): void {
     this.prefs.setAutoQueueEnabled(event.detail.checked);
+  }
+
+  onLanguageChange(event: CustomEvent<{ value: string }>): void {
+    this.languageService.setLanguage(event.detail.value);
   }
 }

--- a/src/app/features/tabs/tabs.component.html
+++ b/src/app/features/tabs/tabs.component.html
@@ -7,22 +7,22 @@
   <ion-tab-bar slot="bottom">
     <ion-tab-button tab="home" href="/tabs/home">
       <ion-icon name="home-outline"></ion-icon>
-      <ion-label>Home</ion-label>
+      <ion-label>{{ 'nav.home' | translate }}</ion-label>
     </ion-tab-button>
 
     <ion-tab-button tab="discover" href="/tabs/discover">
       <ion-icon name="compass-outline"></ion-icon>
-      <ion-label>Discover</ion-label>
+      <ion-label>{{ 'nav.discover' | translate }}</ion-label>
     </ion-tab-button>
 
     <ion-tab-button tab="radio" href="/tabs/radio">
       <ion-icon name="radio-outline"></ion-icon>
-      <ion-label>Radio</ion-label>
+      <ion-label>{{ 'nav.radio' | translate }}</ion-label>
     </ion-tab-button>
 
     <ion-tab-button tab="library" href="/tabs/library">
       <ion-icon name="library-outline"></ion-icon>
-      <ion-label>Library</ion-label>
+      <ion-label>{{ 'nav.library' | translate }}</ion-label>
     </ion-tab-button>
   </ion-tab-bar>
 </ion-tabs>

--- a/src/app/features/tabs/tabs.component.ts
+++ b/src/app/features/tabs/tabs.component.ts
@@ -18,6 +18,7 @@ import {
   libraryOutline,
   library,
 } from 'ionicons/icons';
+import { TranslatePipe } from '@ngx-translate/core';
 import { PlayerStore } from '../../store/player/player.store';
 import { PlayerModalService } from '../../core/services/player-modal.service';
 import { MiniPlayerComponent } from '../player/mini-player/mini-player.component';
@@ -35,6 +36,7 @@ import { OfflineBannerComponent } from '../../shared/components/offline-banner/o
     IonLabel,
     MiniPlayerComponent,
     OfflineBannerComponent,
+    TranslatePipe,
   ],
 })
 export class TabsComponent {

--- a/src/app/shared/components/episode-item/episode-item.component.html
+++ b/src/app/shared/components/episode-item/episode-item.component.html
@@ -33,7 +33,7 @@
     slot="end"
     fill="clear"
     size="small"
-    [attr.aria-label]="'Queue ' + episode().title"
+    [attr.aria-label]="('episode.add_to_queue' | translate) + ' ' + episode().title"
     (click)="emitQueue($event)">
     <ion-icon slot="icon-only" [name]="justAdded() ? 'checkmark-outline' : 'add-outline'"></ion-icon>
   </ion-button>
@@ -42,7 +42,7 @@
     slot="end"
     fill="clear"
     size="small"
-    [attr.aria-label]="'Play ' + episode().title"
+    [attr.aria-label]="('episode.play' | translate) + ' ' + episode().title"
     (click)="emitPlay(); $event.stopPropagation()">
     <ion-icon slot="icon-only" name="play-circle-outline"></ion-icon>
   </ion-button>

--- a/src/app/shared/components/episode-item/episode-item.component.spec.ts
+++ b/src/app/shared/components/episode-item/episode-item.component.spec.ts
@@ -8,9 +8,14 @@ jest.mock('@angular/fire/auth', () => ({
 
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateService } from '@ngx-translate/core';
 
 import { EpisodeItemComponent } from './episode-item.component';
 import { mockEpisode } from '../../../../testing/podcast-fixtures';
+import {
+  loadTranslations,
+  provideTranslateTesting,
+} from '../../../../testing/translate-testing.helper';
 
 describe('EpisodeItemComponent', () => {
   let fixture: ComponentFixture<EpisodeItemComponent>;
@@ -19,6 +24,7 @@ describe('EpisodeItemComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [EpisodeItemComponent],
+      providers: [...provideTranslateTesting()],
       schemas: [NO_ERRORS_SCHEMA],
     })
       .overrideComponent(EpisodeItemComponent, {
@@ -26,6 +32,7 @@ describe('EpisodeItemComponent', () => {
       })
       .compileComponents();
 
+    loadTranslations(TestBed.inject(TranslateService));
     fixture = TestBed.createComponent(EpisodeItemComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('episode', mockEpisode({ id: 'ep-1', podcastId: 'pod-1' }));

--- a/src/app/shared/components/episode-item/episode-item.component.ts
+++ b/src/app/shared/components/episode-item/episode-item.component.ts
@@ -5,12 +5,13 @@ import { addIcons } from 'ionicons';
 import { addOutline, checkmarkOutline, playCircleOutline } from 'ionicons/icons';
 
 import { Episode } from '../../../core/models/podcast.model';
+import { TranslatePipe } from '@ngx-translate/core';
 
 @Component({
   selector: 'wavely-episode-item',
   templateUrl: './episode-item.component.html',
   styleUrls: ['./episode-item.component.scss'],
-  imports: [DatePipe, IonItem, IonThumbnail, IonLabel, IonNote, IonButton, IonIcon],
+  imports: [DatePipe, IonItem, IonThumbnail, IonLabel, IonNote, IonButton, IonIcon, TranslatePipe],
 })
 export class EpisodeItemComponent implements OnDestroy {
   readonly episode = input.required<Episode>();

--- a/src/app/shared/components/offline-banner/offline-banner.component.html
+++ b/src/app/shared/components/offline-banner/offline-banner.component.html
@@ -2,13 +2,13 @@
   <div class="offline-banner" role="status" aria-live="polite">
     <div class="offline-banner__message">
       <ion-icon name="warning-outline" aria-hidden="true"></ion-icon>
-      <span>You are offline. Some content may be unavailable.</span>
+      <span>{{ 'offline.message' | translate }}</span>
     </div>
     <ion-button
       fill="clear"
       size="small"
       color="warning"
-      aria-label="Dismiss offline warning"
+      [attr.aria-label]="'offline.dismiss' | translate"
       (click)="dismiss()">
       <ion-icon name="close-outline" slot="icon-only"></ion-icon>
     </ion-button>

--- a/src/app/shared/components/offline-banner/offline-banner.component.spec.ts
+++ b/src/app/shared/components/offline-banner/offline-banner.component.spec.ts
@@ -1,7 +1,12 @@
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateService } from '@ngx-translate/core';
 
 import { NetworkService } from '../../../core/services/network.service';
+import {
+  loadTranslations,
+  provideTranslateTesting,
+} from '../../../../testing/translate-testing.helper';
 import { OfflineBannerComponent } from './offline-banner.component';
 
 describe('OfflineBannerComponent', () => {
@@ -12,13 +17,12 @@ describe('OfflineBannerComponent', () => {
     await TestBed.configureTestingModule({
       imports: [OfflineBannerComponent],
       providers: [
-        {
-          provide: NetworkService,
-          useValue: { isOnline },
-        },
+        { provide: NetworkService, useValue: { isOnline } },
+        ...provideTranslateTesting(),
       ],
     }).compileComponents();
 
+    loadTranslations(TestBed.inject(TranslateService));
     fixture = TestBed.createComponent(OfflineBannerComponent);
   });
 

--- a/src/app/shared/components/offline-banner/offline-banner.component.ts
+++ b/src/app/shared/components/offline-banner/offline-banner.component.ts
@@ -3,13 +3,14 @@ import { Component, computed, effect, inject, signal } from '@angular/core';
 import { IonButton, IonIcon } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { closeOutline, warningOutline } from 'ionicons/icons';
+import { TranslatePipe } from '@ngx-translate/core';
 import { NetworkService } from '../../../core/services/network.service';
 
 @Component({
   selector: 'wavely-offline-banner',
   templateUrl: './offline-banner.component.html',
   styleUrls: ['./offline-banner.component.scss'],
-  imports: [IonIcon, IonButton],
+  imports: [IonIcon, IonButton, TranslatePipe],
 })
 export class OfflineBannerComponent {
   private readonly network = inject(NetworkService);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -56,6 +56,22 @@
     --wavely-on-surface-muted:#9AA0A6;
     --wavely-player-bg:       #1E1E1E;
 
+    /* Primary — lighter shade for dark surfaces (~6:1 on #1E1E1E) */
+    --wavely-primary:                    #4A9EFF;
+    --wavely-player-progress:            #4A9EFF;
+    --ion-color-primary:                 #4A9EFF;
+    --ion-color-primary-rgb:             74, 158, 255;
+    --ion-color-primary-contrast:        #000000;
+    --ion-color-primary-contrast-rgb:    0, 0, 0;
+    --ion-color-primary-shade:           #4190E0;
+    --ion-color-primary-tint:            #5CA8FF;
+
+    /* Danger — lighter shade for dark surfaces */
+    --ion-color-danger:                  #F28B82;
+    --ion-color-danger-rgb:              242, 139, 130;
+    --ion-color-danger-contrast:         #000000;
+    --ion-color-danger-contrast-rgb:     0, 0, 0;
+
     --ion-background-color:         var(--wavely-background);
     --ion-toolbar-background:       var(--wavely-surface);
     --ion-toolbar-color:            var(--wavely-on-surface);
@@ -73,6 +89,22 @@
   --wavely-on-surface:      #E8EAED;
   --wavely-on-surface-muted:#9AA0A6;
   --wavely-player-bg:       #1E1E1E;
+
+  /* Primary — lighter shade for dark surfaces (~6:1 on #1E1E1E) */
+  --wavely-primary:                    #4A9EFF;
+  --wavely-player-progress:            #4A9EFF;
+  --ion-color-primary:                 #4A9EFF;
+  --ion-color-primary-rgb:             74, 158, 255;
+  --ion-color-primary-contrast:        #000000;
+  --ion-color-primary-contrast-rgb:    0, 0, 0;
+  --ion-color-primary-shade:           #4190E0;
+  --ion-color-primary-tint:            #5CA8FF;
+
+  /* Danger — lighter shade for dark surfaces */
+  --ion-color-danger:                  #F28B82;
+  --ion-color-danger-rgb:              242, 139, 130;
+  --ion-color-danger-contrast:         #000000;
+  --ion-color-danger-contrast-rgb:     0, 0, 0;
 
   --ion-background-color:         var(--wavely-background);
   --ion-toolbar-background:       var(--wavely-surface);

--- a/src/testing/translate-testing.helper.ts
+++ b/src/testing/translate-testing.helper.ts
@@ -1,0 +1,65 @@
+import { Provider } from '@angular/core';
+import {
+  provideTranslateService,
+  TranslateLoader,
+  TranslateNoOpLoader,
+  TranslateService,
+} from '@ngx-translate/core';
+import { Observable, of } from 'rxjs';
+
+/**
+ * Minimal translate setup for unit tests.
+ * Provides TranslateService with English translations so templates render
+ * readable strings instead of raw i18n keys.
+ */
+export function provideTranslateTesting(): Provider[] {
+  return [
+    ...provideTranslateService({
+      fallbackLang: 'en',
+      loader: { provide: TranslateLoader, useClass: TranslateNoOpLoader },
+    }),
+  ];
+}
+
+/**
+ * Call in beforeEach after TestBed is configured to inject translations.
+ * Usage:
+ *   const translateService = TestBed.inject(TranslateService);
+ *   loadTranslations(translateService);
+ */
+export function loadTranslations(translate: TranslateService): void {
+  translate.setTranslation('en', {
+    nav: { home: 'Home', discover: 'Discover', radio: 'Radio', library: 'Library' },
+    home: {
+      title: 'Wavely',
+      my_podcasts: 'My Podcasts',
+      latest_episodes: 'Latest Episodes',
+      trending: 'Trending',
+      load_more: 'Load {{count}} more episodes',
+    },
+    offline: {
+      message: 'You are offline. Some content may be unavailable.',
+      dismiss: 'Dismiss offline warning',
+    },
+    player: {
+      play: 'Play',
+      pause: 'Pause',
+      skip_back: 'Skip back 30 seconds',
+      skip_forward: 'Skip forward 30 seconds',
+      live: 'LIVE',
+      up_next: 'Up Next',
+      empty_queue: 'No episodes in queue',
+      close: 'Close player',
+      add_to_queue: 'Add to queue',
+      queue: 'Queue',
+    },
+    episode: { play: 'Play episode', add_to_queue: 'Add to queue' },
+    podcast_detail: {
+      subscribe: 'Subscribe',
+      unsubscribe: 'Unsubscribe',
+      subscribed: 'Subscribed',
+      episodes: 'Episodes',
+    },
+  });
+  translate.use('en');
+}


### PR DESCRIPTION
## v1.8.0 — Favorite Radio Stations + i18n Fixes

### What's in this release

**v1.8.0 — Favorite Stations on Home Screen**
- `UserPreferencesService` now stores full `RadioStation` objects (not just IDs)
- Backward-compatible migration from legacy `favoriteStationIds`
- Home screen shows a 'Favorite Stations' horizontal scroll section when favorites exist
- Tapping a favorite station plays its live stream directly

**v1.7.0 — i18n (English + Spanish)**
- Full ngx-translate integration across all pages/components
- `LanguageService`: auto-detects browser language, persists to localStorage
- Language picker in Settings (en, es, fr, de, pt)

**v1.8.0 fix — Translation startup fix**
- `LanguageService` injected at app startup (was lazy-loaded only from Settings)
- `TranslateModule.forRoot` updated to v17 API (`fallbackLang` instead of deprecated `defaultLanguage`)
- Fixes E2E failures where translation keys were rendered verbatim

### Changelog
- feat(home,radio): favorite stations on home screen
- feat(i18n): full i18n with ngx-translate
- fix(i18n): load translations at app startup
- fix(i18n): episode keys, skip_back seconds, subscribe aria-label

### Testing
- 285/285 unit tests pass on staging
- Full E2E suite passes on staging

🚀 Deploy target: https://wavely-f659c.web.app