### PR TITLE
fix(e2e): handle desktop viewport in home tab active test

### DIFF
--- a/e2e/src/home.spec.ts
+++ b/e2e/src/home.spec.ts
@@ -93,8 +93,18 @@ test.describe('Home page', () => {
     await page.goto('/tabs');
     await expect(page).toHaveURL(/\/tabs\/home/);
 
-    const homeTab = page.getByRole('tab', { name: /home/i });
-    await expect(homeTab).toHaveAttribute('aria-selected', 'true');
+    // On mobile: ion-tab-bar is visible and home tab should be selected
+    // On desktop: tab bar is hidden and sidebar link carries the active state
+    const tabBar = page.locator('ion-tab-bar');
+    const isDesktop = await tabBar.evaluate((el) => getComputedStyle(el).display === 'none');
+
+    if (isDesktop) {
+      const sidebarHomeLink = page.locator('.desktop-sidebar__link[href$="/tabs/home"]');
+      await expect(sidebarHomeLink).toHaveClass(/active/);
+    } else {
+      const homeTab = page.getByRole('tab', { name: /home/i });
+      await expect(homeTab).toHaveAttribute('aria-selected', 'true');
+    }
   });
 
   test('home page basic smoke render', async ({ page }) => {


### PR DESCRIPTION
## Problem

On desktop viewport (≥992px) the `ion-tab-bar` is hidden via `.desktop-hidden-tabs` CSS introduced in the v1.8.2 desktop layout. CI runs E2E on Desktop Chrome (1280px), so `getByRole('tab', { name: /home/i })` finds no visible elements and the test fails.

## Fix

The test now checks the computed CSS display of `ion-tab-bar`:
- **Desktop** (hidden tab bar): asserts the `.desktop-sidebar__link[href$="/tabs/home"]` element has the `active` class (added by Angular's `routerLinkActive`)  
- **Mobile** (visible tab bar): keeps the original `aria-selected` assertion on the tab button

## Testing

- [x] No TypeScript errors
- [x] Covers both mobile and desktop viewport paths

Closes the E2E failure blocking PR #319 (dev → staging).