### PR TITLE
fix(e2e): set mobile viewport in player tests (#332)

### DIFF
--- a/e2e/src/player.spec.ts
+++ b/e2e/src/player.spec.ts
@@ -46,6 +46,10 @@ function lookupEpisodeResult() {
 test.skip(() => !process.env['USE_EMULATORS'], 'Requires Firebase emulators');
 
 test.describe('Player', () => {
+  // Player tests require mobile viewport — the full-player modal is suppressed on desktop (≥1024px)
+  // to show controls inline instead. Locking to 390px ensures consistent behaviour across CI.
+  test.use({ viewport: { width: 390, height: 844 } });
+
   test.beforeEach(async ({ page }) => {
     // Prevent AudioService from calling store.pause() in CI where real audio
     // URLs can't load. Two guard layers:


### PR DESCRIPTION
Closes #332

## What

Added `test.use({ viewport: { width: 390, height: 844 } })` to the Player `describe` block in `e2e/src/player.spec.ts`.

## Why

`PlayerModalService.open()` (introduced in #328) returns early on viewports ≥1024px — the full-player modal is desktop-suppressed. CI runs on Desktop Chrome (1280×720), so all player modal assertions were failing.

The fix locks player tests to mobile viewport which matches the intended UX: the full-player modal is a mobile-only interaction.