### PR TITLE
fix(player): backport mini-player keyboard UX fixes to dev

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -423,7 +423,7 @@
     <section class="hero">
       <div class="container hero-grid">
         <div class="hero-content">
-          <div class="badge">Early Access <span>v1.5.2</span></div>
+          <div class="badge">Early Access <span>v1.8.3</span></div>
           <h1>Your podcasts.<br>Beautifully organized.</h1>
           <p class="hero-subtitle">
             A free, open-source podcast player built with modern web technologies. Clean design, no ads, and seamless synchronization.
@@ -544,7 +544,7 @@
           <div class="feature-card">
             <div class="feature-icon">🎧</div>
             <h3 class="feature-title">Advanced Player</h3>
-            <p class="feature-text">Variable playback speed (0.5×–2×), skip ±30s, and a persistent mini-player that follows you as you browse. Your listening history is always a tap away.</p>
+            <p class="feature-text">Variable playback speed (0.5×–2×), skip back 15s / forward 30s, and a persistent mini-player that follows you as you browse. On desktop, skip controls appear directly in the mini-player. Your listening history is always a tap away.</p>
           </div>
           
           <div class="feature-card">
@@ -565,7 +565,7 @@
         <a href="mailto:hello@wavely.app" class="footer-link">Contact</a>
       </div>
       <p class="copyright">
-        © 2025 Wavely. Open source project.
+        © 2026 Wavely. Open source project.
       </p>
     </div>
   </footer>

--- a/src/app/features/player/mini-player/mini-player.component.html
+++ b/src/app/features/player/mini-player/mini-player.component.html
@@ -5,8 +5,8 @@
        [attr.tabindex]="isDesktop ? null : '0'"
        [attr.aria-label]="isDesktop ? null : ('player.open_full' | translate)"
        (click)="handleBodyClick()"
-       (keydown.enter)="isDesktop ? null : handleBodyClick()"
-       (keydown.space)="isDesktop ? null : handleBodyClick()">
+       (keydown.enter)="isDesktop ? null : handleBodyClick($event)"
+       (keydown.space)="isDesktop ? null : handleBodyClick($event)">
     <ion-progress-bar
       class="mini-player__progress"
       [value]="progressValue"

--- a/src/app/features/player/mini-player/mini-player.component.ts
+++ b/src/app/features/player/mini-player/mini-player.component.ts
@@ -22,7 +22,7 @@ export class MiniPlayerComponent {
   readonly store = inject(PlayerStore);
   private readonly playerModal = inject(PlayerModalService);
 
-  /** Emitted when user taps the player body — parent opens full player */
+  /** Emitted when user taps the player body on non-desktop — parent opens full player (desktop tap is a no-op) */
   readonly openFull = output<void>();
 
   constructor() {
@@ -38,7 +38,10 @@ export class MiniPlayerComponent {
     return this.playerModal.isDesktop;
   }
 
-  handleBodyClick(): void {
+  handleBodyClick(event?: Event): void {
+    if (event instanceof KeyboardEvent) {
+      event.preventDefault();
+    }
     if (!this.isDesktop) {
       this.openFull.emit();
     }


### PR DESCRIPTION
Backport of fixes that landed in v1.8.3 promote → main but weren't in dev:

- `keydown.enter` now passes `$event` to `handleBodyClick()` (consistency with space)
- `handleBodyClick()` calls `event.preventDefault()` for keyboard events to prevent page scroll
- `docs/index.html`: skip description updated to 'skip back 15s / forward 30s'
- JSDoc comment updated to note desktop tap is a no-op

Related to #332.