### PR TITLE
fix(episode-item): increase queue feedback duration to 2000ms + add OnPush

### DIFF
--- a/src/app/shared/components/episode-item/episode-item.component.spec.ts
+++ b/src/app/shared/components/episode-item/episode-item.component.spec.ts
@@ -73,4 +73,59 @@ describe('EpisodeItemComponent', () => {
     component['onImageError']({ target: image } as never);
     expect(image.src).toContain('/default-artwork.svg');
   });
+
+  describe('emitQueue', () => {
+    let mockEvent: Event;
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      mockEvent = { stopPropagation: jest.fn() } as unknown as Event;
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('emits addToQueue with the current episode', () => {
+      const ep = mockEpisode({ id: 'ep-2', podcastId: 'pod-1' });
+      fixture.componentRef.setInput('episode', ep);
+      fixture.detectChanges();
+
+      const queued: typeof ep[] = [];
+      component.addToQueue.subscribe((e) => queued.push(e));
+
+      component['emitQueue'](mockEvent);
+
+      expect(queued).toHaveLength(1);
+      expect(queued[0].id).toBe('ep-2');
+    });
+
+    it('calls stopPropagation on the event', () => {
+      component['emitQueue'](mockEvent);
+      expect(mockEvent.stopPropagation).toHaveBeenCalled();
+    });
+
+    it('sets justAdded to true immediately', () => {
+      component['emitQueue'](mockEvent);
+      expect(component.justAdded()).toBe(true);
+    });
+
+    it('resets justAdded to false after 2000ms', () => {
+      component['emitQueue'](mockEvent);
+      expect(component.justAdded()).toBe(true);
+
+      jest.advanceTimersByTime(2000);
+
+      expect(component.justAdded()).toBe(false);
+    });
+
+    it('does not reset justAdded before 2000ms', () => {
+      component['emitQueue'](mockEvent);
+      jest.advanceTimersByTime(1999);
+      expect(component.justAdded()).toBe(true);
+
+      jest.advanceTimersByTime(1);
+      expect(component.justAdded()).toBe(false);
+    });
+  });
 });

--- a/src/app/shared/components/episode-item/episode-item.component.ts
+++ b/src/app/shared/components/episode-item/episode-item.component.ts
@@ -1,5 +1,5 @@
 import { DatePipe } from '@angular/common';
-import { Component, OnDestroy, input, output, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, input, output, signal } from '@angular/core';
 import { IonButton, IonIcon, IonItem, IonLabel, IonNote, IonThumbnail } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
 import { addOutline, checkmarkOutline, playCircleOutline } from 'ionicons/icons';
@@ -11,6 +11,7 @@ import { TranslatePipe } from '@ngx-translate/core';
   selector: 'wavely-episode-item',
   templateUrl: './episode-item.component.html',
   styleUrls: ['./episode-item.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [DatePipe, IonItem, IonThumbnail, IonLabel, IonNote, IonButton, IonIcon, TranslatePipe],
 })
 export class EpisodeItemComponent implements OnDestroy {
@@ -50,7 +51,7 @@ export class EpisodeItemComponent implements OnDestroy {
     this.justAddedTimer = setTimeout(() => {
       this.justAdded.set(false);
       this.justAddedTimer = null;
-    }, 1500);
+    }, 2000);
   }
 
   protected formatDuration(seconds: number): string {


### PR DESCRIPTION
Fixes #336 - queue feedback disappears too quickly.

Changes:
- EpisodeItemComponent: add ChangeDetectionStrategy.OnPush (was missing)
- EpisodeItemComponent: increase justAdded timeout 1500ms -> 2000ms
- Spec: 5 new tests for emitQueue (output, stopPropagation, justAdded state, 2000ms boundary)