### PR TITLE
feat(design-tokens): elevation, radius, spacing, layout CSS variables (#339)

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -34,6 +34,30 @@
   --wavely-player-bg:       #FFFFFF;
   --wavely-player-progress: #1A73E8;
 
+  /* Layout */
+  --sidebar-width:                220px;
+  --sidebar-collapsed-width:      72px;
+  --player-rail-width:            320px;
+
+  /* Elevation */
+  --wavely-elevation-1: 0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.06);
+  --wavely-elevation-2: 0 4px 12px rgba(0,0,0,0.1), 0 2px 4px rgba(0,0,0,0.06);
+  --wavely-elevation-3: 0 8px 24px rgba(0,0,0,0.14), 0 4px 8px rgba(0,0,0,0.08);
+
+  /* Border-radius */
+  --wavely-radius-sm:             4px;
+  --wavely-radius-md:             8px;
+  --wavely-radius-lg:             12px;
+  --wavely-radius-xl:             16px;
+
+  /* Spacing */
+  --wavely-spacing-xs:            4px;
+  --wavely-spacing-sm:            8px;
+  --wavely-spacing-md:            16px;
+  --wavely-spacing-lg:            24px;
+  --wavely-spacing-xl:            32px;
+  --wavely-spacing-2xl:           48px;
+
   /* Ionic overrides */
   --ion-background-color:         var(--wavely-background);
   --ion-toolbar-background:       var(--wavely-surface);
@@ -57,6 +81,11 @@
     --wavely-on-surface-muted:   #9AA0A6;
     --wavely-on-surface-variant: #9AA0A6;
     --wavely-player-bg:       #1E1E1E;
+
+    /* Elevation — darker shadows for dark surfaces */
+    --wavely-elevation-1: 0 1px 3px rgba(0,0,0,0.24), 0 1px 2px rgba(0,0,0,0.18);
+    --wavely-elevation-2: 0 4px 12px rgba(0,0,0,0.32), 0 2px 4px rgba(0,0,0,0.22);
+    --wavely-elevation-3: 0 8px 24px rgba(0,0,0,0.42), 0 4px 8px rgba(0,0,0,0.28);
 
     /* Primary — lighter shade for dark surfaces (~6:1 on #1E1E1E) */
     --wavely-primary:                    #4A9EFF;
@@ -92,6 +121,11 @@
   --wavely-on-surface-muted:   #9AA0A6;
   --wavely-on-surface-variant: #9AA0A6;
   --wavely-player-bg:       #1E1E1E;
+
+  /* Elevation — darker shadows for dark surfaces */
+  --wavely-elevation-1: 0 1px 3px rgba(0,0,0,0.24), 0 1px 2px rgba(0,0,0,0.18);
+  --wavely-elevation-2: 0 4px 12px rgba(0,0,0,0.32), 0 2px 4px rgba(0,0,0,0.22);
+  --wavely-elevation-3: 0 8px 24px rgba(0,0,0,0.42), 0 4px 8px rgba(0,0,0,0.28);
 
   /* Primary — lighter shade for dark surfaces (~6:1 on #1E1E1E) */
   --wavely-primary:                    #4A9EFF;


### PR DESCRIPTION
## Summary
Adds CSS custom property design tokens as the foundation for the v1.9.0 desktop redesign.

## New tokens
- **Layout**: `--sidebar-width`, `--sidebar-collapsed-width`, `--player-rail-width`
- **Elevation**: 3-level scale with dark-mode overrides
- **Border-radius**: sm/md/lg/xl scale
- **Spacing**: xs through 2xl scale

## Notes
- Pure CSS change — zero functional impact
- No existing tokens renamed or removed
- All values follow existing Wavely naming conventions
- Dark mode elevation tokens added to existing dark mode block

## Part of
Epic #338 — v1.9.0 Desktop Experience Redesign
Milestone: v1.9.0 — Desktop Experience

Closes #339