### PR TITLE
feat(shell): three-panel desktop layout + collapsible sidebar (#340)

### DIFF
--- a/src/app/features/tabs/tabs.component.html
+++ b/src/app/features/tabs/tabs.component.html
@@ -1,33 +1,44 @@
 <wavely-offline-banner></wavely-offline-banner>
 
-<div class="tabs-layout">
+<div class="tabs-layout" [class.sidebar-collapsed]="layoutStore.sidebarCollapsed()">
   <nav class="desktop-sidebar" aria-label="Main navigation">
     <div class="desktop-sidebar__logo">
       <img src="icons/icon-192x192.png" alt="Wavely" width="32" height="32" />
+      <span class="desktop-sidebar__logo-text">Wavely</span>
     </div>
     <div class="desktop-sidebar__links">
-      <a routerLink="/tabs/home" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" class="desktop-sidebar__link">
-        <ion-icon name="home-outline"></ion-icon>
-        <span>{{ 'nav.home' | translate }}</span>
+      <a routerLink="/tabs/home" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }"
+         class="desktop-sidebar__link" [title]="'nav.home' | translate">
+        <ion-icon name="home-outline" aria-hidden="true"></ion-icon>
+        <span class="desktop-sidebar__label">{{ 'nav.home' | translate }}</span>
       </a>
-      <a routerLink="/tabs/discover" routerLinkActive="active" class="desktop-sidebar__link">
-        <ion-icon name="compass-outline"></ion-icon>
-        <span>{{ 'nav.discover' | translate }}</span>
+      <a routerLink="/tabs/discover" routerLinkActive="active"
+         class="desktop-sidebar__link" [title]="'nav.discover' | translate">
+        <ion-icon name="compass-outline" aria-hidden="true"></ion-icon>
+        <span class="desktop-sidebar__label">{{ 'nav.discover' | translate }}</span>
       </a>
-      <a routerLink="/tabs/radio" routerLinkActive="active" class="desktop-sidebar__link">
-        <ion-icon name="radio-outline"></ion-icon>
-        <span>{{ 'nav.radio' | translate }}</span>
+      <a routerLink="/tabs/radio" routerLinkActive="active"
+         class="desktop-sidebar__link" [title]="'nav.radio' | translate">
+        <ion-icon name="radio-outline" aria-hidden="true"></ion-icon>
+        <span class="desktop-sidebar__label">{{ 'nav.radio' | translate }}</span>
       </a>
-      <a routerLink="/tabs/library" routerLinkActive="active" class="desktop-sidebar__link">
-        <ion-icon name="library-outline"></ion-icon>
-        <span>{{ 'nav.library' | translate }}</span>
+      <a routerLink="/tabs/library" routerLinkActive="active"
+         class="desktop-sidebar__link" [title]="'nav.library' | translate">
+        <ion-icon name="library-outline" aria-hidden="true"></ion-icon>
+        <span class="desktop-sidebar__label">{{ 'nav.library' | translate }}</span>
       </a>
     </div>
     <div class="desktop-sidebar__footer">
-      <a routerLink="/settings" routerLinkActive="active" class="desktop-sidebar__link">
-        <ion-icon name="settings-outline"></ion-icon>
-        <span>{{ 'nav.settings' | translate }}</span>
+      <a routerLink="/settings" routerLinkActive="active"
+         class="desktop-sidebar__link" [title]="'nav.settings' | translate">
+        <ion-icon name="settings-outline" aria-hidden="true"></ion-icon>
+        <span class="desktop-sidebar__label">{{ 'nav.settings' | translate }}</span>
       </a>
+      <button class="desktop-sidebar__collapse-btn"
+              (click)="layoutStore.toggleSidebar()"
+              [attr.aria-label]="layoutStore.sidebarCollapsed() ? 'Expand sidebar' : 'Collapse sidebar'">
+        <ion-icon [name]="layoutStore.sidebarCollapsed() ? 'chevron-forward' : 'chevron-back'" aria-hidden="true"></ion-icon>
+      </button>
     </div>
   </nav>
 
@@ -57,4 +68,9 @@
       </ion-tab-button>
     </ion-tab-bar>
   </ion-tabs>
+
+  @if (store.currentEpisode()) {
+    <!-- Player rail placeholder — DesktopPlayerComponent will go here in #341 -->
+    <aside class="desktop-player-rail" aria-label="Now playing"></aside>
+  }
 </div>

--- a/src/app/features/tabs/tabs.component.scss
+++ b/src/app/features/tabs/tabs.component.scss
@@ -20,30 +20,40 @@ ion-tab-button {
 
 @media (min-width: 1024px) {
   :host {
-    display: flex;
+    display: block;
     height: 100%;
   }
 
   .tabs-layout {
-    display: flex;
-    flex: 1;
+    display: grid;
+    grid-template-columns: var(--sidebar-width) 1fr 0px;
+    grid-template-rows: 1fr;
     height: 100%;
+    transition: grid-template-columns 200ms ease;
+
+    &.sidebar-collapsed {
+      grid-template-columns: var(--sidebar-collapsed-width) 1fr 0px;
+    }
+
+    &:has(.desktop-player-rail) {
+      grid-template-columns: var(--sidebar-width) 1fr var(--player-rail-width);
+    }
+
+    &.sidebar-collapsed:has(.desktop-player-rail) {
+      grid-template-columns: var(--sidebar-collapsed-width) 1fr var(--player-rail-width);
+    }
   }
 
   .desktop-sidebar {
     display: flex;
     flex-direction: column;
-    width: 220px;
-    min-width: 220px;
+    grid-column: 1;
     height: 100%;
     background: var(--wavely-surface);
     border-right: 1px solid var(--wavely-divider);
     padding: 16px 0;
     z-index: 100;
-    position: fixed;
-    left: 0;
-    top: 0;
-    bottom: 0;
+    overflow: hidden;
   }
 
   .desktop-sidebar__logo {
@@ -54,6 +64,17 @@ ion-tab-button {
     font-weight: 700;
     font-size: 1.1rem;
     color: var(--wavely-on-surface);
+  }
+
+  .desktop-sidebar__logo-text {
+    transition: opacity 150ms ease, width 150ms ease;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+
+  .sidebar-collapsed .desktop-sidebar__logo-text {
+    opacity: 0;
+    width: 0;
   }
 
   .desktop-sidebar__links {
@@ -67,6 +88,9 @@ ion-tab-button {
   .desktop-sidebar__footer {
     padding: 8px 8px 4px;
     border-top: 1px solid var(--wavely-divider);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
   }
 
   .desktop-sidebar__link {
@@ -74,7 +98,7 @@ ion-tab-button {
     align-items: center;
     gap: 12px;
     padding: 10px 12px;
-    border-radius: 8px;
+    border-radius: var(--wavely-radius-md);
     color: var(--wavely-on-surface-muted);
     text-decoration: none;
     font-size: 0.9rem;
@@ -97,14 +121,56 @@ ion-tab-button {
     }
   }
 
+  .desktop-sidebar__label {
+    transition: opacity 150ms ease, width 150ms ease;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+
+  .sidebar-collapsed .desktop-sidebar__label {
+    opacity: 0;
+    width: 0;
+    margin: 0;
+  }
+
+  .desktop-sidebar__collapse-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: var(--wavely-radius-md);
+    border: none;
+    background: transparent;
+    color: var(--wavely-on-surface-muted);
+    cursor: pointer;
+    transition: background 0.15s;
+
+    &:hover {
+      background: var(--wavely-surface-variant);
+      color: var(--wavely-on-surface);
+    }
+
+    ion-icon {
+      font-size: 20px;
+    }
+  }
+
+  ion-tabs {
+    grid-column: 2;
+    overflow: hidden;
+  }
+
+  .desktop-player-rail {
+    grid-column: 3;
+    height: 100%;
+    background: var(--wavely-surface);
+    border-left: 1px solid var(--wavely-divider);
+    overflow-y: auto;
+  }
+
   // Hide the Ionic bottom tab bar on desktop
   .desktop-hidden-tabs {
     display: none !important;
-  }
-
-  // Push main content to the right of the sidebar
-  ion-tabs {
-    flex: 1;
-    margin-left: 220px;
   }
 }

--- a/src/app/features/tabs/tabs.component.spec.ts
+++ b/src/app/features/tabs/tabs.component.spec.ts
@@ -6,11 +6,13 @@ jest.mock('@angular/fire/auth', () => ({
   signOut: jest.fn(),
 }));
 
+import { signal } from '@angular/core';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsComponent } from './tabs.component';
 import { PlayerStore } from '../../store/player/player.store';
+import { LayoutStore } from '../../store/layout/layout.store';
 import { PlayerModalService } from '../../core/services/player-modal.service';
 
 describe('TabsComponent', () => {
@@ -26,11 +28,24 @@ describe('TabsComponent', () => {
     playbackRate: jest.fn(() => 1),
   };
 
+  const sidebarCollapsedSignal = signal(false);
+  const mockLayoutStore = {
+    sidebarCollapsed: sidebarCollapsedSignal,
+    queueFocused: signal(false),
+    sidebarWidth: signal('var(--sidebar-width)'),
+    initFromStorage: jest.fn(),
+    toggleSidebar: jest.fn(),
+    toggleQueue: jest.fn(),
+  };
+
   beforeEach(async () => {
+    localStorage.clear();
+
     await TestBed.configureTestingModule({
       imports: [TabsComponent],
       providers: [
         { provide: PlayerStore, useValue: mockPlayerStore },
+        { provide: LayoutStore, useValue: mockLayoutStore },
         { provide: PlayerModalService, useValue: mockPlayerModal },
       ],
       schemas: [NO_ERRORS_SCHEMA],
@@ -45,11 +60,20 @@ describe('TabsComponent', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    localStorage.clear();
     TestBed.resetTestingModule();
   });
 
   it('creates successfully', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('calls initFromStorage on construction', () => {
+    expect(mockLayoutStore.initFromStorage).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes layoutStore publicly for template binding', () => {
+    expect(component.layoutStore).toBe(mockLayoutStore);
   });
 
   it('opens full player when episode is playing', async () => {
@@ -62,5 +86,10 @@ describe('TabsComponent', () => {
     mockPlayerStore.currentEpisode.mockReturnValue(null);
     await component.openFullPlayer();
     expect(mockPlayerModal.open).not.toHaveBeenCalled();
+  });
+
+  it('toggleSidebar() delegates to layoutStore', () => {
+    component.layoutStore.toggleSidebar();
+    expect(mockLayoutStore.toggleSidebar).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/features/tabs/tabs.component.ts
+++ b/src/app/features/tabs/tabs.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 
 import {
@@ -20,9 +20,12 @@ import {
   library,
   searchOutline,
   settingsOutline,
+  chevronBack,
+  chevronForward,
 } from 'ionicons/icons';
 import { TranslatePipe } from '@ngx-translate/core';
 import { PlayerStore } from '../../store/player/player.store';
+import { LayoutStore } from '../../store/layout/layout.store';
 import { PlayerModalService } from '../../core/services/player-modal.service';
 import { MiniPlayerComponent } from '../player/mini-player/mini-player.component';
 import { OfflineBannerComponent } from '../../shared/components/offline-banner/offline-banner.component';
@@ -31,6 +34,7 @@ import { OfflineBannerComponent } from '../../shared/components/offline-banner/o
   selector: 'wavely-tabs',
   templateUrl: './tabs.component.html',
   styleUrls: ['./tabs.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     IonTabs,
     IonTabBar,
@@ -46,6 +50,7 @@ import { OfflineBannerComponent } from '../../shared/components/offline-banner/o
 })
 export class TabsComponent {
   readonly store = inject(PlayerStore);
+  readonly layoutStore = inject(LayoutStore);
   private readonly playerModal = inject(PlayerModalService);
 
   constructor() {
@@ -60,7 +65,10 @@ export class TabsComponent {
       library,
       searchOutline,
       settingsOutline,
+      chevronBack,
+      chevronForward,
     });
+    this.layoutStore.initFromStorage();
   }
 
   async openFullPlayer(): Promise<void> {

--- a/src/app/store/layout/layout.store.spec.ts
+++ b/src/app/store/layout/layout.store.spec.ts
@@ -1,0 +1,131 @@
+import { TestBed } from '@angular/core/testing';
+import { PLATFORM_ID } from '@angular/core';
+import { LayoutStore } from './layout.store';
+
+describe('LayoutStore', () => {
+  let store: InstanceType<typeof LayoutStore>;
+
+  function createStore(platformId = 'browser') {
+    TestBed.configureTestingModule({
+      providers: [
+        LayoutStore,
+        { provide: PLATFORM_ID, useValue: platformId },
+      ],
+    });
+    return TestBed.inject(LayoutStore);
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    store = createStore();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    TestBed.resetTestingModule();
+  });
+
+  describe('initial state', () => {
+    it('has sidebarCollapsed false by default', () => {
+      expect(store.sidebarCollapsed()).toBe(false);
+    });
+
+    it('has queueFocused false by default', () => {
+      expect(store.queueFocused()).toBe(false);
+    });
+
+    it('sidebarWidth computed returns expanded width', () => {
+      expect(store.sidebarWidth()).toBe('var(--sidebar-width)');
+    });
+  });
+
+  describe('toggleSidebar()', () => {
+    it('flips sidebarCollapsed to true', () => {
+      store.toggleSidebar();
+      expect(store.sidebarCollapsed()).toBe(true);
+    });
+
+    it('flips sidebarCollapsed back to false on second call', () => {
+      store.toggleSidebar();
+      store.toggleSidebar();
+      expect(store.sidebarCollapsed()).toBe(false);
+    });
+
+    it('writes collapsed state to localStorage', () => {
+      store.toggleSidebar();
+      expect(localStorage.getItem('wavely-sidebar-collapsed')).toBe('true');
+    });
+
+    it('writes expanded state to localStorage after second toggle', () => {
+      store.toggleSidebar();
+      store.toggleSidebar();
+      expect(localStorage.getItem('wavely-sidebar-collapsed')).toBe('false');
+    });
+
+    it('updates sidebarWidth computed to collapsed width', () => {
+      store.toggleSidebar();
+      expect(store.sidebarWidth()).toBe('var(--sidebar-collapsed-width)');
+    });
+
+    it('still toggles state when localStorage throws', () => {
+      jest.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new DOMException('SecurityError');
+      });
+      store.toggleSidebar();
+      expect(store.sidebarCollapsed()).toBe(true);
+      jest.restoreAllMocks();
+    });
+  });
+
+  describe('initFromStorage()', () => {
+    it('sets sidebarCollapsed to true when localStorage has "true"', () => {
+      localStorage.setItem('wavely-sidebar-collapsed', 'true');
+      store.initFromStorage();
+      expect(store.sidebarCollapsed()).toBe(true);
+    });
+
+    it('leaves sidebarCollapsed false when localStorage has "false"', () => {
+      localStorage.setItem('wavely-sidebar-collapsed', 'false');
+      store.initFromStorage();
+      expect(store.sidebarCollapsed()).toBe(false);
+    });
+
+    it('leaves sidebarCollapsed false when localStorage key is absent', () => {
+      store.initFromStorage();
+      expect(store.sidebarCollapsed()).toBe(false);
+    });
+
+    it('does not throw when localStorage throws', () => {
+      jest.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new DOMException('SecurityError');
+      });
+      expect(() => store.initFromStorage()).not.toThrow();
+      jest.restoreAllMocks();
+    });
+  });
+
+  describe('initFromStorage() on server platform', () => {
+    it('is a no-op on server platform (does not access localStorage)', () => {
+      TestBed.resetTestingModule();
+      const serverStore = createStore('server');
+      const spy = jest.spyOn(Storage.prototype, 'getItem');
+      serverStore.initFromStorage();
+      expect(spy).not.toHaveBeenCalled();
+      expect(serverStore.sidebarCollapsed()).toBe(false);
+      jest.restoreAllMocks();
+    });
+  });
+
+  describe('toggleQueue()', () => {
+    it('flips queueFocused to true', () => {
+      store.toggleQueue();
+      expect(store.queueFocused()).toBe(true);
+    });
+
+    it('flips queueFocused back to false on second call', () => {
+      store.toggleQueue();
+      store.toggleQueue();
+      expect(store.queueFocused()).toBe(false);
+    });
+  });
+});

--- a/src/app/store/layout/layout.store.ts
+++ b/src/app/store/layout/layout.store.ts
@@ -1,0 +1,51 @@
+import { computed, inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { patchState, signalStore, withComputed, withMethods, withState } from '@ngrx/signals';
+
+interface LayoutState {
+  sidebarCollapsed: boolean;
+  queueFocused: boolean;
+}
+
+const initialState: LayoutState = {
+  sidebarCollapsed: false,
+  queueFocused: false,
+};
+
+export const LayoutStore = signalStore(
+  { providedIn: 'root' },
+  withState(initialState),
+  withComputed(({ sidebarCollapsed }) => ({
+    sidebarWidth: computed(() =>
+      sidebarCollapsed() ? 'var(--sidebar-collapsed-width)' : 'var(--sidebar-width)'
+    ),
+  })),
+  withMethods((store) => {
+    const isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+    return {
+      initFromStorage(): void {
+        if (!isBrowser) return;
+        try {
+          const saved = localStorage.getItem('wavely-sidebar-collapsed');
+          if (saved === 'true') patchState(store, { sidebarCollapsed: true });
+        } catch {
+          // localStorage unavailable (strict privacy mode / security policy) — use default state
+        }
+      },
+      toggleSidebar(): void {
+        const next = !store.sidebarCollapsed();
+        patchState(store, { sidebarCollapsed: next });
+        if (isBrowser) {
+          try {
+            localStorage.setItem('wavely-sidebar-collapsed', String(next));
+          } catch {
+            // localStorage unavailable — state still toggled in memory
+          }
+        }
+      },
+      toggleQueue(): void {
+        patchState(store, { queueFocused: !store.queueFocused() });
+      },
+    };
+  })
+);


### PR DESCRIPTION
## Summary
Refactors the desktop app shell into a CSS Grid three-panel layout and introduces `LayoutStore` for sidebar state management.

## Changes

### New: `LayoutStore`
NgRx SignalStore (`providedIn: 'root'`) at `src/app/store/layout/layout.store.ts`:
- `sidebarCollapsed` signal with localStorage persistence
- `queueFocused` signal for future queue panel
- `toggleSidebar()` / `toggleQueue()` / `initFromStorage()` methods
- `isPlatformBrowser` guard + try/catch on all localStorage calls (SSR safety — matches pattern used by ThemeService, CountryService, etc.)

### Refactored: `TabsComponent`
- CSS Grid three-panel: `var(--sidebar-width) 1fr var(--player-rail-width)`
- Sidebar collapses to `var(--sidebar-collapsed-width)` (72px) with animated label fade
- Collapse toggle button in sidebar footer
- Player rail `<aside>` slot — empty now, `DesktopPlayerComponent` added in #341
- `ChangeDetectionStrategy.OnPush` added
- Removed `position: fixed` + `margin-left` approach

## Mobile
Zero changes below 1024px — all existing mobile tests pass.

## Tests
- New: `layout.store.spec.ts` — 12 tests covering state, toggling, localStorage persistence, server-platform no-op, and error resilience
- Updated: `tabs.component.spec.ts` — adds LayoutStore mock and 3 new assertions

## Part of
Epic #338 — v1.9.0 Desktop Experience Redesign
Milestone: v1.9.0 — Desktop Experience

Closes #340