### PR TITLE
feat(player): DesktopPlayerComponent — right-rail player panel (#341)

### DIFF
--- a/src/app/core/services/audio.service.ts
+++ b/src/app/core/services/audio.service.ts
@@ -149,6 +149,14 @@ export class AudioService {
       });
     });
 
+    // Sync volume to HTMLAudioElement
+    effect(() => {
+      const vol = this.store.effectiveVolume();
+      untracked(() => {
+        if (this.audio) this.audio.volume = vol;
+      });
+    });
+
     // Respond to user-initiated seeks (store.seek() jumps > 1 second)
     effect(() => {
       const storeTime = this.store.currentTime();

--- a/src/app/features/player/desktop-player/desktop-player.component.html
+++ b/src/app/features/player/desktop-player/desktop-player.component.html
@@ -1,0 +1,135 @@
+<div class="desktop-player">
+  <!-- Artwork -->
+  <div class="desktop-player__artwork-wrap">
+    <img
+      class="desktop-player__artwork"
+      [src]="store.currentEpisode()!.imageUrl || '/default-artwork.svg'"
+      [alt]="store.currentEpisode()!.title"
+      [ngClass]="{ 'desktop-player__artwork--playing': store.isPlaying() }"
+    />
+    <!-- Waveform animation -->
+    @if (store.isPlaying()) {
+      <div class="waveform" aria-hidden="true">
+        @for (bar of [1, 2, 3, 4, 5]; track bar) {
+          <span class="waveform__bar"></span>
+        }
+      </div>
+    }
+  </div>
+
+  <!-- Episode info -->
+  <div class="desktop-player__info">
+    <p class="desktop-player__podcast">{{ store.currentEpisode()?.podcastId }}</p>
+    <h3 class="desktop-player__title">{{ store.currentEpisode()!.title }}</h3>
+  </div>
+
+  <!-- Progress scrubber (hidden for live streams) -->
+  @if (!store.currentEpisode()?.isLive) {
+    <div class="desktop-player__scrubber">
+      <span class="desktop-player__time">{{ currentTimeFormatted }}</span>
+      <input
+        type="range"
+        class="desktop-player__seek"
+        min="0"
+        max="100"
+        step="0.1"
+        [value]="progressValue * 100"
+        (change)="onSeek($event)"
+        aria-label="Seek"
+      />
+      <span class="desktop-player__time desktop-player__time--remaining">{{ remainingTimeFormatted }}</span>
+    </div>
+  }
+  @if (store.currentEpisode()?.isLive) {
+    <div class="desktop-player__live-badge">● LIVE</div>
+  }
+
+  <!-- Controls -->
+  <div class="desktop-player__controls">
+    @if (!store.currentEpisode()?.isLive) {
+      <ion-button fill="clear" (click)="store.skipBack(15)" aria-label="Skip back 15 seconds">
+        <ion-icon slot="icon-only" name="play-skip-back"></ion-icon>
+      </ion-button>
+    }
+    <ion-button
+      fill="clear"
+      class="desktop-player__play-btn"
+      (click)="togglePlay()"
+      [attr.aria-label]="store.isPlaying() ? 'Pause' : 'Play'"
+    >
+      <ion-icon slot="icon-only" [name]="store.isPlaying() ? 'pause-circle' : 'play-circle'"></ion-icon>
+    </ion-button>
+    @if (!store.currentEpisode()?.isLive) {
+      <ion-button fill="clear" (click)="store.skipForward(30)" aria-label="Skip forward 30 seconds">
+        <ion-icon slot="icon-only" name="play-skip-forward"></ion-icon>
+      </ion-button>
+    }
+    <ion-button fill="clear" (click)="store.close()" aria-label="Close player">
+      <ion-icon slot="icon-only" name="close-outline"></ion-icon>
+    </ion-button>
+  </div>
+
+  <!-- Playback rate (hidden for live) -->
+  @if (!store.currentEpisode()?.isLive) {
+    <div class="desktop-player__rate">
+      @for (rate of playbackRates; track rate) {
+        <button
+          class="desktop-player__rate-btn"
+          [class.desktop-player__rate-btn--active]="store.playbackRate() === rate"
+          (click)="setRate(rate)"
+        >
+          {{ rate }}×
+        </button>
+      }
+    </div>
+  }
+
+  <!-- Volume control -->
+  <div class="desktop-player__volume">
+    <ion-button
+      fill="clear"
+      (click)="store.toggleMute()"
+      [attr.aria-label]="store.isMuted() ? 'Unmute' : 'Mute'"
+    >
+      <ion-icon slot="icon-only" [name]="store.isMuted() ? 'volume-mute' : 'volume-high'"></ion-icon>
+    </ion-button>
+    <input
+      type="range"
+      class="desktop-player__volume-slider"
+      min="0"
+      max="1"
+      step="0.01"
+      [value]="store.isMuted() ? 0 : store.volume()"
+      (input)="onVolumeChange($event)"
+      aria-label="Volume"
+    />
+  </div>
+
+  <!-- Queue -->
+  @if (store.queue().length > 0) {
+    <div class="desktop-player__queue">
+      <div class="desktop-player__queue-header">
+        <span>Up Next ({{ store.queue().length }})</span>
+        <button class="desktop-player__queue-clear" (click)="store.clearQueue()">Clear</button>
+      </div>
+      <ul class="desktop-player__queue-list">
+        @for (episode of store.queue(); track episode.id) {
+          <li class="desktop-player__queue-item">
+            <img
+              [src]="episode.imageUrl || '/default-artwork.svg'"
+              [alt]="episode.title"
+              width="40"
+              height="40"
+            />
+            <div class="desktop-player__queue-info">
+              <span class="desktop-player__queue-title">{{ episode.title }}</span>
+            </div>
+            <button (click)="store.removeFromQueue(episode.id)" aria-label="Remove from queue">
+              <ion-icon name="close-outline"></ion-icon>
+            </button>
+          </li>
+        }
+      </ul>
+    </div>
+  }
+</div>

--- a/src/app/features/player/desktop-player/desktop-player.component.scss
+++ b/src/app/features/player/desktop-player/desktop-player.component.scss
@@ -1,0 +1,270 @@
+:host {
+  display: block;
+  height: 100%;
+  overflow-y: auto;
+}
+
+.desktop-player {
+  display: flex;
+  flex-direction: column;
+  padding: var(--wavely-spacing-lg);
+  gap: var(--wavely-spacing-md);
+  height: 100%;
+
+  &__artwork-wrap {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 1;
+    max-width: 240px;
+    margin: 0 auto;
+  }
+
+  &__artwork {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: var(--wavely-radius-lg);
+    box-shadow: var(--wavely-elevation-2);
+    transition: transform 300ms ease;
+
+    &--playing {
+      transform: scale(1.02);
+    }
+  }
+
+  &__info {
+    text-align: center;
+  }
+
+  &__podcast {
+    font-size: 0.75rem;
+    color: var(--wavely-on-surface-muted);
+    margin: 0 0 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  &__title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--wavely-on-surface);
+    margin: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  &__scrubber {
+    display: flex;
+    align-items: center;
+    gap: var(--wavely-spacing-sm);
+  }
+
+  &__seek {
+    flex: 1;
+    height: 4px;
+    accent-color: var(--wavely-primary);
+    cursor: pointer;
+  }
+
+  &__time {
+    font-size: 0.75rem;
+    color: var(--wavely-on-surface-muted);
+    min-width: 36px;
+    text-align: center;
+  }
+
+  &__live-badge {
+    text-align: center;
+    color: #e53935;
+    font-weight: 700;
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+  }
+
+  &__controls {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--wavely-spacing-sm);
+
+    ion-button {
+      --padding-start: 8px;
+      --padding-end: 8px;
+    }
+  }
+
+  &__play-btn {
+    ion-icon {
+      font-size: 48px;
+    }
+  }
+
+  &__rate {
+    display: flex;
+    justify-content: center;
+    gap: var(--wavely-spacing-xs);
+    flex-wrap: wrap;
+  }
+
+  &__rate-btn {
+    padding: 4px 10px;
+    border-radius: var(--wavely-radius-sm);
+    border: 1px solid var(--wavely-divider);
+    background: transparent;
+    color: var(--wavely-on-surface-muted);
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition:
+      background 0.15s,
+      color 0.15s;
+
+    &:hover {
+      background: var(--wavely-surface-variant);
+      color: var(--wavely-on-surface);
+    }
+
+    &--active {
+      background: var(--wavely-primary);
+      color: #fff;
+      border-color: var(--wavely-primary);
+      font-weight: 600;
+    }
+  }
+
+  &__volume {
+    display: flex;
+    align-items: center;
+    gap: var(--wavely-spacing-sm);
+  }
+
+  &__volume-slider {
+    flex: 1;
+    height: 4px;
+    accent-color: var(--wavely-primary);
+    cursor: pointer;
+  }
+
+  &__queue {
+    border-top: 1px solid var(--wavely-divider);
+    padding-top: var(--wavely-spacing-md);
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  &__queue-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: var(--wavely-spacing-sm);
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--wavely-on-surface-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  &__queue-clear {
+    background: none;
+    border: none;
+    color: var(--wavely-primary);
+    font-size: 0.75rem;
+    cursor: pointer;
+  }
+
+  &__queue-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    overflow-y: auto;
+    flex: 1;
+  }
+
+  &__queue-item {
+    display: flex;
+    align-items: center;
+    gap: var(--wavely-spacing-sm);
+    padding: var(--wavely-spacing-xs) 0;
+    border-bottom: 1px solid var(--wavely-divider);
+
+    img {
+      border-radius: var(--wavely-radius-sm);
+      flex-shrink: 0;
+    }
+
+    button {
+      background: none;
+      border: none;
+      color: var(--wavely-on-surface-muted);
+      cursor: pointer;
+      flex-shrink: 0;
+      padding: 4px;
+    }
+  }
+
+  &__queue-info {
+    flex: 1;
+    min-width: 0;
+  }
+
+  &__queue-title {
+    font-size: 0.8rem;
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+// Waveform animation
+.waveform {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 24px;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: var(--wavely-radius-sm);
+  padding: 4px 8px;
+
+  &__bar {
+    width: 3px;
+    border-radius: 2px;
+    background: #fff;
+    animation: waveform 0.8s ease-in-out infinite alternate;
+
+    @for $i from 1 through 5 {
+      &:nth-child(#{$i}) {
+        animation-delay: #{($i - 1) * 0.12}s;
+        height: #{4 + ($i % 3) * 4}px;
+      }
+    }
+  }
+}
+
+@keyframes waveform {
+  from {
+    height: 4px;
+  }
+  to {
+    height: 20px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .waveform__bar {
+    animation: none;
+    height: 8px !important;
+  }
+
+  .desktop-player__artwork--playing {
+    transform: none;
+  }
+}

--- a/src/app/features/player/desktop-player/desktop-player.component.spec.ts
+++ b/src/app/features/player/desktop-player/desktop-player.component.spec.ts
@@ -1,0 +1,210 @@
+// DesktopPlayerComponent imports AudioService → AuthStore → AuthService → @angular/fire/auth,
+// which calls `fetch` at module load in Jest's Node environment. Mocking prevents the crash.
+jest.mock('@angular/fire/auth', () => ({
+  Auth: class MockAuth {},
+  user: jest.fn(),
+  GoogleAuthProvider: class {},
+  signInWithPopup: jest.fn(),
+  signOut: jest.fn(),
+}));
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA, PLATFORM_ID } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { DesktopPlayerComponent } from './desktop-player.component';
+import { PlayerStore } from '../../../store/player/player.store';
+import { AudioService } from '../../../core/services/audio.service';
+import { mockPlayerStore } from '../../../../testing/mock-stores';
+import { mockEpisode } from '../../../../testing/podcast-fixtures';
+import {
+  loadTranslations,
+  provideTranslateTesting,
+} from '../../../../testing/translate-testing.helper';
+
+describe('DesktopPlayerComponent', () => {
+  let component: DesktopPlayerComponent;
+  let fixture: ComponentFixture<DesktopPlayerComponent>;
+  let store: ReturnType<typeof mockPlayerStore>;
+
+  function createComponent(storeOverrides = {}): void {
+    store = mockPlayerStore({
+      currentEpisode: mockEpisode({ id: 'ep-1', title: 'Test Episode', podcastId: 'pod-1' }),
+      ...storeOverrides,
+    });
+
+    TestBed.configureTestingModule({
+      imports: [DesktopPlayerComponent],
+      providers: [
+        { provide: PlayerStore, useValue: store },
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        ...provideTranslateTesting(),
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    loadTranslations(TestBed.inject(TranslateService));
+    fixture = TestBed.createComponent(DesktopPlayerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  describe('component creation', () => {
+    it('creates successfully', () => {
+      createComponent();
+      expect(component).toBeTruthy();
+    });
+
+    it('injects PlayerStore', () => {
+      createComponent();
+      expect(component.store).toBeDefined();
+    });
+  });
+
+  describe('progressValue', () => {
+    it('returns 0 when duration is 0', () => {
+      createComponent({ currentTime: 0, duration: 0 });
+      expect(component.progressValue).toBe(0);
+    });
+
+    it('returns 0 when duration is 0 even with non-zero currentTime', () => {
+      createComponent({ currentTime: 30, duration: 0 });
+      expect(component.progressValue).toBe(0);
+    });
+
+    it('returns correct ratio', () => {
+      createComponent({ currentTime: 30, duration: 120 });
+      expect(component.progressValue).toBeCloseTo(0.25);
+    });
+
+    it('returns 1.0 when at full duration', () => {
+      createComponent({ currentTime: 3600, duration: 3600 });
+      expect(component.progressValue).toBe(1);
+    });
+
+    it('returns 0.5 at halfway point', () => {
+      createComponent({ currentTime: 60, duration: 120 });
+      expect(component.progressValue).toBeCloseTo(0.5);
+    });
+  });
+
+  describe('currentTimeFormatted', () => {
+    it('delegates to AudioService.formatTime', () => {
+      createComponent({ currentTime: 90, duration: 300 });
+      expect(component.currentTimeFormatted).toBe(AudioService.formatTime(90));
+    });
+
+    it('formats 0 as 0:00', () => {
+      createComponent({ currentTime: 0, duration: 300 });
+      expect(component.currentTimeFormatted).toBe('0:00');
+    });
+
+    it('formats minutes and seconds correctly', () => {
+      createComponent({ currentTime: 125, duration: 300 });
+      expect(component.currentTimeFormatted).toBe('2:05');
+    });
+  });
+
+  describe('remainingTimeFormatted', () => {
+    it('delegates to AudioService.formatTime with a minus prefix', () => {
+      createComponent({ currentTime: 30, duration: 120 });
+      const remaining = 120 - 30;
+      expect(component.remainingTimeFormatted).toBe('-' + AudioService.formatTime(remaining));
+    });
+
+    it('clamps remaining to 0 when currentTime exceeds duration', () => {
+      createComponent({ currentTime: 150, duration: 120 });
+      expect(component.remainingTimeFormatted).toBe('-0:00');
+    });
+
+    it('shows full duration remaining at start', () => {
+      createComponent({ currentTime: 0, duration: 600 });
+      expect(component.remainingTimeFormatted).toBe('-' + AudioService.formatTime(600));
+    });
+  });
+
+  describe('togglePlay()', () => {
+    it('calls store.pause() when currently playing', () => {
+      createComponent({ isPlaying: true });
+      component.togglePlay();
+      expect(store.pause).toHaveBeenCalledTimes(1);
+      expect(store.resume).not.toHaveBeenCalled();
+    });
+
+    it('calls store.resume() when currently paused', () => {
+      createComponent({ isPlaying: false });
+      component.togglePlay();
+      expect(store.resume).toHaveBeenCalledTimes(1);
+      expect(store.pause).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onSeek()', () => {
+    it('calls store.seek() with correct time', () => {
+      createComponent({ currentTime: 0, duration: 200 });
+      const mockEvent = { target: { value: '50' } } as unknown as Event;
+      component.onSeek(mockEvent);
+      // 50% of 200 = 100
+      expect(store.seek).toHaveBeenCalledWith(100);
+    });
+
+    it('seeks to 0 when value is 0', () => {
+      createComponent({ currentTime: 60, duration: 200 });
+      const mockEvent = { target: { value: '0' } } as unknown as Event;
+      component.onSeek(mockEvent);
+      expect(store.seek).toHaveBeenCalledWith(0);
+    });
+
+    it('seeks to full duration when value is 100', () => {
+      createComponent({ currentTime: 0, duration: 300 });
+      const mockEvent = { target: { value: '100' } } as unknown as Event;
+      component.onSeek(mockEvent);
+      expect(store.seek).toHaveBeenCalledWith(300);
+    });
+  });
+
+  describe('onVolumeChange()', () => {
+    it('calls store.setVolume() with parsed float value', () => {
+      createComponent();
+      const mockEvent = { target: { value: '0.7' } } as unknown as Event;
+      component.onVolumeChange(mockEvent);
+      expect(store.setVolume).toHaveBeenCalledWith(0.7);
+    });
+
+    it('calls store.setVolume() with 0 for silence', () => {
+      createComponent();
+      const mockEvent = { target: { value: '0' } } as unknown as Event;
+      component.onVolumeChange(mockEvent);
+      expect(store.setVolume).toHaveBeenCalledWith(0);
+    });
+
+    it('calls store.setVolume() with 1 for max', () => {
+      createComponent();
+      const mockEvent = { target: { value: '1' } } as unknown as Event;
+      component.onVolumeChange(mockEvent);
+      expect(store.setVolume).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('setRate()', () => {
+    it('calls store.setPlaybackRate() with the given rate', () => {
+      createComponent();
+      component.setRate(1.5);
+      expect(store.setPlaybackRate).toHaveBeenCalledWith(1.5);
+    });
+
+    it('calls store.setPlaybackRate() with 0.5', () => {
+      createComponent();
+      component.setRate(0.5);
+      expect(store.setPlaybackRate).toHaveBeenCalledWith(0.5);
+    });
+  });
+
+  describe('playbackRates', () => {
+    it('contains expected rates', () => {
+      createComponent();
+      expect(component.playbackRates).toEqual([0.5, 0.75, 1, 1.25, 1.5, 2]);
+    });
+  });
+});

--- a/src/app/features/player/desktop-player/desktop-player.component.ts
+++ b/src/app/features/player/desktop-player/desktop-player.component.ts
@@ -1,0 +1,82 @@
+import { Component, ChangeDetectionStrategy, inject } from '@angular/core';
+import { NgClass } from '@angular/common';
+import { IonIcon, IonButton } from '@ionic/angular/standalone';
+import { addIcons } from 'ionicons';
+import {
+  playCircle,
+  pauseCircle,
+  closeCircle,
+  playSkipBack,
+  playSkipForward,
+  volumeHigh,
+  volumeMute,
+  list,
+  closeOutline,
+} from 'ionicons/icons';
+import { PlayerStore } from '../../../store/player/player.store';
+import { AudioService } from '../../../core/services/audio.service';
+import { TranslatePipe } from '@ngx-translate/core';
+
+@Component({
+  selector: 'wavely-desktop-player',
+  templateUrl: './desktop-player.component.html',
+  styleUrls: ['./desktop-player.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [IonIcon, IonButton, NgClass, TranslatePipe],
+})
+export class DesktopPlayerComponent {
+  readonly store = inject(PlayerStore);
+
+  constructor() {
+    addIcons({
+      playCircle,
+      pauseCircle,
+      closeCircle,
+      playSkipBack,
+      playSkipForward,
+      volumeHigh,
+      volumeMute,
+      list,
+      closeOutline,
+    });
+  }
+
+  get progressValue(): number {
+    const dur = this.store.duration();
+    return dur > 0 ? this.store.currentTime() / dur : 0;
+  }
+
+  get currentTimeFormatted(): string {
+    return AudioService.formatTime(this.store.currentTime());
+  }
+
+  get remainingTimeFormatted(): string {
+    const remaining = Math.max(0, this.store.duration() - this.store.currentTime());
+    return '-' + AudioService.formatTime(remaining);
+  }
+
+  togglePlay(): void {
+    if (this.store.isPlaying()) {
+      this.store.pause();
+    } else {
+      this.store.resume();
+    }
+  }
+
+  onSeek(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const time = (parseFloat(input.value) / 100) * this.store.duration();
+    this.store.seek(time);
+  }
+
+  onVolumeChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.store.setVolume(parseFloat(input.value));
+  }
+
+  readonly playbackRates = [0.5, 0.75, 1, 1.25, 1.5, 2];
+
+  setRate(rate: number): void {
+    this.store.setPlaybackRate(rate);
+  }
+}

--- a/src/app/features/tabs/tabs.component.html
+++ b/src/app/features/tabs/tabs.component.html
@@ -70,7 +70,8 @@
   </ion-tabs>
 
   @if (store.currentEpisode()) {
-    <!-- Player rail placeholder — DesktopPlayerComponent will go here in #341 -->
-    <aside class="desktop-player-rail" aria-label="Now playing"></aside>
+    <aside class="desktop-player-rail" aria-label="Now playing">
+      <wavely-desktop-player></wavely-desktop-player>
+    </aside>
   }
 </div>

--- a/src/app/features/tabs/tabs.component.scss
+++ b/src/app/features/tabs/tabs.component.scss
@@ -173,4 +173,9 @@ ion-tab-button {
   .desktop-hidden-tabs {
     display: none !important;
   }
+
+  // Hide mini-player on desktop — it's replaced by the right-rail DesktopPlayerComponent
+  wavely-mini-player {
+    display: none !important;
+  }
 }

--- a/src/app/features/tabs/tabs.component.ts
+++ b/src/app/features/tabs/tabs.component.ts
@@ -28,6 +28,7 @@ import { PlayerStore } from '../../store/player/player.store';
 import { LayoutStore } from '../../store/layout/layout.store';
 import { PlayerModalService } from '../../core/services/player-modal.service';
 import { MiniPlayerComponent } from '../player/mini-player/mini-player.component';
+import { DesktopPlayerComponent } from '../player/desktop-player/desktop-player.component';
 import { OfflineBannerComponent } from '../../shared/components/offline-banner/offline-banner.component';
 
 @Component({
@@ -42,6 +43,7 @@ import { OfflineBannerComponent } from '../../shared/components/offline-banner/o
     IonIcon,
     IonLabel,
     MiniPlayerComponent,
+    DesktopPlayerComponent,
     OfflineBannerComponent,
     TranslatePipe,
     RouterLink,

--- a/src/app/store/player/player.store.spec.ts
+++ b/src/app/store/player/player.store.spec.ts
@@ -266,4 +266,74 @@ describe('PlayerStore', () => {
       expect(store.duration()).toBe(0);
     });
   });
+
+  describe('setVolume()', () => {
+    it('sets volume and clears isMuted', () => {
+      store.toggleMute();
+      store.setVolume(0.6);
+      expect(store.volume()).toBe(0.6);
+      expect(store.isMuted()).toBe(false);
+    });
+
+    it('clamps volume below 0 to 0', () => {
+      store.setVolume(-0.5);
+      expect(store.volume()).toBe(0);
+    });
+
+    it('clamps volume above 1 to 1', () => {
+      store.setVolume(1.5);
+      expect(store.volume()).toBe(1);
+    });
+
+    it('ignores NaN — does not corrupt volume state', () => {
+      store.setVolume(0.5);
+      store.setVolume(NaN);
+      expect(store.volume()).toBe(0.5); // unchanged
+    });
+
+    it('Infinity clamps to 1 (max volume)', () => {
+      store.setVolume(0.4);
+      store.setVolume(Infinity);
+      expect(store.volume()).toBe(1); // clamped by Math.min(1, Infinity) = 1
+    });
+
+    it('accepts exactly 1', () => {
+      store.setVolume(1);
+      expect(store.volume()).toBe(1);
+    });
+  });
+
+  describe('toggleMute()', () => {
+    it('flips isMuted from false to true', () => {
+      expect(store.isMuted()).toBe(false);
+      store.toggleMute();
+      expect(store.isMuted()).toBe(true);
+    });
+
+    it('flips isMuted back to false', () => {
+      store.toggleMute();
+      store.toggleMute();
+      expect(store.isMuted()).toBe(false);
+    });
+  });
+
+  describe('effectiveVolume()', () => {
+    it('returns volume when not muted', () => {
+      store.setVolume(0.7);
+      expect(store.effectiveVolume()).toBe(0.7);
+    });
+
+    it('returns 0 when muted regardless of volume', () => {
+      store.setVolume(0.8);
+      store.toggleMute();
+      expect(store.effectiveVolume()).toBe(0);
+    });
+
+    it('returns volume again after unmute', () => {
+      store.setVolume(0.8);
+      store.toggleMute();
+      store.toggleMute();
+      expect(store.effectiveVolume()).toBe(0.8);
+    });
+  });
 });

--- a/src/app/store/player/player.store.ts
+++ b/src/app/store/player/player.store.ts
@@ -1,4 +1,5 @@
-import { signalStore, withState, withMethods, patchState } from '@ngrx/signals';
+import { computed } from '@angular/core';
+import { signalStore, withState, withMethods, withComputed, patchState } from '@ngrx/signals';
 import { Episode } from '../../core/models/podcast.model';
 
 export interface PlayerState {
@@ -9,6 +10,8 @@ export interface PlayerState {
   playbackRate: number;
   queue: Episode[];
   isMinimised: boolean;
+  volume: number;
+  isMuted: boolean;
 }
 
 const initialState: PlayerState = {
@@ -19,11 +22,16 @@ const initialState: PlayerState = {
   playbackRate: 1,
   queue: [],
   isMinimised: true,
+  volume: 1,
+  isMuted: false,
 };
 
 export const PlayerStore = signalStore(
   { providedIn: 'root' },
   withState(initialState),
+  withComputed((store) => ({
+    effectiveVolume: computed(() => (store.isMuted() ? 0 : store.volume())),
+  })),
   withMethods((store) => ({
     play(episode: Episode): void {
       patchState(store, { currentEpisode: episode, isPlaying: true, currentTime: 0 });
@@ -83,6 +91,14 @@ export const PlayerStore = signalStore(
     /** Dismiss player entirely */
     close(): void {
       patchState(store, { currentEpisode: null, isPlaying: false, currentTime: 0, duration: 0 });
+    },
+    setVolume(volume: number): void {
+      const clamped = Math.max(0, Math.min(1, volume));
+      if (!isFinite(clamped)) return;
+      patchState(store, { volume: clamped, isMuted: false });
+    },
+    toggleMute(): void {
+      patchState(store, { isMuted: !store.isMuted() });
     },
   }))
 );

--- a/src/testing/mock-stores.ts
+++ b/src/testing/mock-stores.ts
@@ -12,6 +12,8 @@ export function mockPlayerStore(overrides: Partial<PlayerState> = {}) {
     playbackRate: 1,
     queue: [],
     isMinimised: true,
+    volume: 1,
+    isMuted: false,
     ...overrides,
   };
 
@@ -23,6 +25,9 @@ export function mockPlayerStore(overrides: Partial<PlayerState> = {}) {
     playbackRate: signal(state.playbackRate),
     queue: signal(state.queue),
     isMinimised: signal(state.isMinimised),
+    volume: signal(state.volume),
+    isMuted: signal(state.isMuted),
+    effectiveVolume: signal(state.isMuted ? 0 : state.volume),
     play: jest.fn(),
     pause: jest.fn(),
     resume: jest.fn(),
@@ -38,6 +43,8 @@ export function mockPlayerStore(overrides: Partial<PlayerState> = {}) {
     skipForward: jest.fn(),
     playNext: jest.fn(),
     close: jest.fn(),
+    setVolume: jest.fn(),
+    toggleMute: jest.fn(),
   };
 }
 


### PR DESCRIPTION
## Summary
Adds the persistent desktop player panel to the right rail of the three-panel shell.

## New: `DesktopPlayerComponent`
Full player experience in a 320px right rail:
- Artwork (scaled up when playing) with CSS waveform animation
- Progress scrubber with seek + current/remaining time display
- Play/Pause, Skip Back 15s, Skip Forward 30s, Close controls
- Playback rate selector (0.5×–2×)
- Volume slider + mute toggle
- Up Next queue list with remove + clear
- Live stream mode (hides scrubber, skip, rate picker; shows LIVE badge)
- `prefers-reduced-motion` respected

## PlayerStore changes
- Added `volume` (0–1, default 1) and `isMuted` (default false) to state
- Added `setVolume()`, `toggleMute()` methods
- Added `effectiveVolume` computed (0 when muted)
- `setVolume()` guards against NaN to prevent HTMLAudioElement crash

## AudioService
- New effect syncs `store.effectiveVolume()` → `HTMLAudioElement.volume`

## Shell
- Mini-player hidden on desktop via CSS (mobile unaffected)
- `DesktopPlayerComponent` wired into `<aside class="desktop-player-rail">`

## Tests
- 375 passing (+35 new: store volume/mute/effectiveVolume, component unit tests)

## Part of
Epic #338 — v1.9.0 Desktop Experience Redesign
Milestone: v1.9.0 — Desktop Experience

Closes #341