### PR TITLE
feat(home): desktop grid layout + inline page title (#342)

### DIFF
--- a/src/app/features/discover/discover.page.html
+++ b/src/app/features/discover/discover.page.html
@@ -12,6 +12,8 @@
   </ion-toolbar>
 </ion-header>
 
+<h1 class="desktop-page-title">{{ 'discover.title' | translate }}</h1>
+
 <ion-content>
   <div class="search-bar-wrapper">
     <ion-searchbar

--- a/src/app/features/discover/discover.page.scss
+++ b/src/app/features/discover/discover.page.scss
@@ -151,12 +151,53 @@ ion-chip {
   font-size: 18px;
 }
 
+.desktop-page-title {
+  display: none;
+}
 
 @media (min-width: 1024px) {
+  ion-header {
+    display: none;
+  }
+
+  .desktop-page-title {
+    display: block;
+    padding: var(--wavely-spacing-xl) var(--wavely-spacing-xl) 0;
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--wavely-on-surface);
+    letter-spacing: -0.5px;
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+
+  ion-content {
+    --padding-start: var(--wavely-spacing-xl);
+    --padding-end: var(--wavely-spacing-xl);
+    --padding-top: var(--wavely-spacing-md);
+  }
+
+  .search-bar-wrapper {
+    padding: var(--wavely-spacing-md) 0;
+    margin: 0 var(--wavely-spacing-xl);
+    background: var(--wavely-background);
+  }
+
+  .podcast-grid {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: var(--wavely-spacing-lg);
+  }
+
   .discover-section {
-    max-width: 1200px;
+    max-width: 1400px;
     margin: 0 auto;
     padding: 0 48px;
+  }
+
+  .section-title {
+    font-size: 20px;
+    font-weight: 600;
+    margin-bottom: var(--wavely-spacing-md);
   }
 
   .category-scroll {


### PR DESCRIPTION
## Summary
Desktop-optimized layout for the Home page: multi-column grids, hidden toolbar, inline page title.

## Changes
- `ion-header` hidden on desktop via CSS
- Inline `<h1>` desktop page title (hidden on mobile)
- My Podcasts: `auto-fill minmax(140px, 1fr)` grid
- Favorite Stations: `auto-fill minmax(100px, 1fr)` grid
- Latest Episodes: two-column grid
- Trending: `auto-fill minmax(180px, 1fr)` grid (4+ columns at 1280px)
- 1400px max-width container, auto margins

## Mobile
Zero changes below 1024px.

## Part of
Epic #338 — v1.9.0 Desktop Experience Redesign
Milestone: v1.9.0 — Desktop Experience

Closes #342