### PR TITLE
feat(discover): desktop 4-column grid + sticky search (#345)

### DIFF
--- a/src/app/features/discover/discover.page.html
+++ b/src/app/features/discover/discover.page.html
@@ -12,6 +12,16 @@
   </ion-toolbar>
 </ion-header>
 
+<div class="desktop-page-header">
+  <h1 class="desktop-page-title">{{ 'discover.title' | translate }}</h1>
+  <ion-button
+    class="country-toggle"
+    [attr.aria-label]="'Discovering ' + currentMarketName + ' content, tap to change'"
+    (click)="presentCountryPicker()">
+    <span class="country-toggle__flag">{{ countryService.getFlag(countryService.country()) }}</span>
+  </ion-button>
+</div>
+
 <ion-content>
   <div class="search-bar-wrapper">
     <ion-searchbar

--- a/src/app/features/discover/discover.page.scss
+++ b/src/app/features/discover/discover.page.scss
@@ -151,12 +151,63 @@ ion-chip {
   font-size: 18px;
 }
 
+.desktop-page-header {
+  display: none;
+}
+
+.desktop-page-title {
+  flex: 1;
+  margin: 0;
+}
 
 @media (min-width: 1024px) {
+  ion-header {
+    display: none;
+  }
+
+  .desktop-page-header {
+    display: flex;
+    align-items: center;
+    gap: var(--wavely-spacing-md);
+    padding: var(--wavely-spacing-xl) var(--wavely-spacing-xl) 0;
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+
+  .desktop-page-title {
+    font-size: 28px;
+    font-weight: 700;
+    color: var(--wavely-on-surface);
+    letter-spacing: -0.5px;
+  }
+
+  ion-content {
+    --padding-start: var(--wavely-spacing-xl);
+    --padding-end: var(--wavely-spacing-xl);
+    --padding-top: var(--wavely-spacing-md);
+  }
+
+  .search-bar-wrapper {
+    padding: var(--wavely-spacing-md) 0;
+    margin: 0 var(--wavely-spacing-xl);
+    background: var(--wavely-background);
+  }
+
+  .podcast-grid {
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: var(--wavely-spacing-lg);
+  }
+
   .discover-section {
-    max-width: 1200px;
+    max-width: 1400px;
     margin: 0 auto;
     padding: 0 48px;
+  }
+
+  .section-title {
+    font-size: 20px;
+    font-weight: 600;
+    margin-bottom: var(--wavely-spacing-md);
   }
 
   .category-scroll {


### PR DESCRIPTION
## Summary
Desktop-optimized Discover/Browse page with 4-column podcast grid and sticky search.

## Changes
- ion-header hidden on desktop (>=1024px)
- desktop-page-header: flex row with inline h1 title + country-toggle (preserves market picker when header is hidden)
- podcast-grid: auto-fill minmax(180px, 1fr) — 4+ columns at >=1280px
- Sticky ion-searchbar wrapper (padding/margin desktop override; sticky was already global)
- discover-section: max-width bumped 1200px to 1400px
- section-title: 20px/600 on desktop
- category-row: already flex-wrapped in pre-existing media query

## Mobile
All changes inside @media (min-width: 1024px) — zero mobile regressions.

## Part of
Epic #338 — v1.9.0 Desktop Experience Redesign
Milestone: v1.9.0 — Desktop Experience

Closes #345